### PR TITLE
Fix config file handling

### DIFF
--- a/src/abt/build_abt.py
+++ b/src/abt/build_abt.py
@@ -2,7 +2,9 @@
 import pandas as pd, yfinance as yf, ta, yaml, os
 from pathlib import Path
 
-CONFIG = yaml.safe_load(open(os.path.join(os.path.dirname(__file__), '../../config.yaml')))
+# Load configuration from the project root
+with open(os.path.join(os.path.dirname(__file__), '../../config.yaml')) as cfg_file:
+    CONFIG = yaml.safe_load(cfg_file)
 DATA_DIR = Path(os.path.join(os.path.dirname(__file__), '../../data'))
 DATA_DIR.mkdir(exist_ok=True, parents=True)
 


### PR DESCRIPTION
## Summary
- use context manager when loading config in `build_abt`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6855f95c1564832cbd4c96136c2f1d51