### PR TITLE
Refactor pipeline modules and drop telegram/streamlit

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,15 @@
-# yahoo
+# Yahoo Finance Pipeline
+
+Este proyecto contiene utilidades para seleccionar acciones, procesar datos,
+entrenar modelos de predicción y evaluar resultados.
+
+Las partes principales incluyen:
+
+1. **Selección de acciones**: se eligen diez valores basados en volumen,
+   estabilidad y rendimiento de los últimos seis meses.
+2. **Procesamiento**: descarga de información desde Yahoo Finance y cálculo de
+   indicadores técnicos.
+3. **Entrenamiento**: se entrenan modelos diarios y semanales y se guardan en
+   la carpeta `models`.
+4. **Predicción y evaluación**: se aplican los modelos guardados y se registran
+   las métricas de precisión y detección de _drift_.

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,5 @@ xgboost>=2.0
 gymnasium[other]>=1.4
 stable-baselines3>=2.3
 schedule>=1.2
-python-telegram-bot>=20.7
 PyYAML>=6.0
-streamlit>=1.34
+joblib>=1.3

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,0 +1,9 @@
+"""Convenience imports for project modules."""
+
+from . import abt, models, notify, portfolio
+from .selection import select_tickers
+from .preprocess import extract_data, preprocess_data
+from .training import train_models
+from .predict import load_models, run_predictions
+from .evaluation import evaluate_predictions, detect_drift
+

--- a/src/evaluation.py
+++ b/src/evaluation.py
@@ -1,0 +1,23 @@
+"""Model evaluation and drift detection."""
+import logging
+from typing import Sequence
+
+import numpy as np
+from sklearn.metrics import mean_absolute_error, r2_score
+
+logger = logging.getLogger(__name__)
+
+
+def evaluate_predictions(y_true: Sequence[float], y_pred: Sequence[float]) -> dict:
+    """Return basic regression metrics."""
+    mae = mean_absolute_error(y_true, y_pred)
+    r2 = r2_score(y_true, y_pred)
+    return {"MAE": mae, "R2": r2}
+
+
+def detect_drift(prev: Sequence[float], curr: Sequence[float], threshold: float = 0.1) -> bool:
+    """Simple drift detection comparing prediction distributions."""
+    prev = np.array(prev)
+    curr = np.array(curr)
+    diff = np.abs(prev - curr).mean()
+    return diff > threshold

--- a/src/notify/notifier.py
+++ b/src/notify/notifier.py
@@ -1,4 +1,4 @@
-"""Utilities to send email and Telegram notifications."""
+"""Utility functions to send email notifications."""
 import logging
 import time
 from typing import Any
@@ -20,15 +20,3 @@ def send_email(message: str, **kwargs) -> None:
         logger.info("Email notification finished in %.2f seconds", duration)
 
 
-def send_telegram(message: str, **kwargs) -> None:
-    start = time.perf_counter()
-    logger.info("Sending Telegram notification")
-    try:
-        # Placeholder for telegram sending logic
-        pass
-    except Exception:
-        logger.exception("Error while sending telegram message")
-        raise
-    finally:
-        duration = time.perf_counter() - start
-        logger.info("Telegram notification finished in %.2f seconds", duration)

--- a/src/predict.py
+++ b/src/predict.py
@@ -1,0 +1,43 @@
+"""Apply trained models to new data and store predictions."""
+import logging
+from pathlib import Path
+from typing import Dict, Any
+
+import joblib
+import pandas as pd
+
+from sklearn.metrics import mean_absolute_error, r2_score
+
+logger = logging.getLogger(__name__)
+
+RESULTS_DIR = Path(__file__).resolve().parents[1] / "results"
+RESULTS_DIR.mkdir(exist_ok=True, parents=True)
+
+
+def load_models(model_dir: Path) -> Dict[str, Any]:
+    models = {}
+    for file in model_dir.glob("*.pkl"):
+        models[file.stem] = joblib.load(file)
+    return models
+
+
+def run_predictions(models: Dict[str, Any], data: Dict[str, pd.DataFrame]) -> pd.DataFrame:
+    rows = []
+    for name, model in models.items():
+        ticker = name.split("_")[0]
+        df = data.get(ticker)
+        if df is None:
+            continue
+        X = df.drop(columns=["Close"], errors="ignore")
+        y = df.get("Close")
+        preds = getattr(model, "predict", lambda X: None)(X)
+        if preds is None:
+            continue
+        mae = mean_absolute_error(y, preds)
+        r2 = r2_score(y, preds)
+        rows.append({"ticker": ticker, "mae": mae, "r2": r2, "actual": y.iloc[-1], "pred": preds[-1]})
+    result_df = pd.DataFrame(rows)
+    out_file = RESULTS_DIR / "predictions.csv"
+    result_df.to_csv(out_file, index=False)
+    logger.info("Saved predictions to %s", out_file)
+    return result_df

--- a/src/preprocess.py
+++ b/src/preprocess.py
@@ -1,0 +1,41 @@
+"""Data extraction and preprocessing utilities."""
+import logging
+from typing import Dict, List
+
+import pandas as pd
+import ta
+import yfinance as yf
+
+from .utils import timed_stage
+
+logger = logging.getLogger(__name__)
+
+
+def extract_data(tickers: List[str], start: str) -> Dict[str, pd.DataFrame]:
+    """Download raw price data for a list of tickers."""
+    data = {}
+    for t in tickers:
+        with timed_stage(f"download {t}"):
+            df = yf.download(t, start=start, progress=False)
+            data[t] = df
+    return data
+
+
+def enrich_features(df: pd.DataFrame) -> pd.DataFrame:
+    """Add common technical indicators."""
+    if df.empty:
+        return df
+    df = df.copy()
+    df["rsi"] = ta.momentum.RSIIndicator(df["Close"]).rsi()
+    df["sma_20"] = ta.trend.SMAIndicator(df["Close"], window=20).sma_indicator()
+    df["sma_50"] = ta.trend.SMAIndicator(df["Close"], window=50).sma_indicator()
+    return df
+
+
+def preprocess_data(data: Dict[str, pd.DataFrame]) -> Dict[str, pd.DataFrame]:
+    """Apply feature enrichment to all dataframes."""
+    processed = {}
+    for t, df in data.items():
+        with timed_stage(f"preprocess {t}"):
+            processed[t] = enrich_features(df)
+    return processed

--- a/src/selection.py
+++ b/src/selection.py
@@ -1,0 +1,49 @@
+"""Stock selection utilities."""
+import logging
+from datetime import datetime, timedelta
+from typing import List
+
+import pandas as pd
+import yfinance as yf
+
+logger = logging.getLogger(__name__)
+
+
+def _fetch_history(ticker: str, start: str, end: str) -> pd.DataFrame:
+    """Download OHLCV data for a ticker."""
+    return yf.download(ticker, start=start, end=end, progress=False)
+
+
+def select_tickers(candidates: List[str], end_date: str) -> List[str]:
+    """Select 10 tickers based on volume, stability and performance."""
+    end_dt = pd.to_datetime(end_date)
+    start_dt = end_dt - pd.DateOffset(months=6)
+    metrics = {}
+
+    for ticker in candidates:
+        df = _fetch_history(ticker, start_dt.strftime("%Y-%m-%d"), end_dt.strftime("%Y-%m-%d"))
+        if df.empty:
+            logger.warning("No data for %s", ticker)
+            continue
+        avg_vol = df["Volume"].mean()
+        returns = df["Close"].pct_change().dropna()
+        volatility = returns.std()
+        total_return = df["Close"].iloc[-1] / df["Close"].iloc[0] - 1
+        metrics[ticker] = {
+            "volume": avg_vol,
+            "volatility": volatility,
+            "return": total_return,
+        }
+
+    vol_sorted = sorted(metrics.items(), key=lambda x: x[1]["volume"], reverse=True)
+    top_volume = [t for t, _ in vol_sorted[:5]]
+
+    stable_sorted = sorted(metrics.items(), key=lambda x: x[1]["volatility"])
+    most_stable = [t for t, _ in stable_sorted if t not in top_volume][:3]
+
+    loser_sorted = sorted(metrics.items(), key=lambda x: x[1]["return"])
+    biggest_losers = [t for t, _ in loser_sorted if t not in top_volume + most_stable][:2]
+
+    selection = top_volume + most_stable + biggest_losers
+    logger.info("Selected tickers: %s", selection)
+    return selection

--- a/src/training.py
+++ b/src/training.py
@@ -1,0 +1,46 @@
+"""Model training pipeline."""
+import logging
+from pathlib import Path
+from typing import Dict
+
+import joblib
+import pandas as pd
+
+from .models.lstm_model import train_lstm
+from .models.rf_model import train_rf
+from .models.xgb_model import train_xgb
+from .utils import timed_stage
+
+logger = logging.getLogger(__name__)
+
+
+MODEL_DIR = Path(__file__).resolve().parents[1] / "models"
+MODEL_DIR.mkdir(exist_ok=True, parents=True)
+
+
+def train_models(data: Dict[str, pd.DataFrame], frequency: str = "daily") -> Dict[str, Path]:
+    """Train placeholder models and persist them to disk."""
+    paths = {}
+    for ticker, df in data.items():
+        X = df.drop(columns=["Close"], errors="ignore")
+        y = df.get("Close")
+
+        with timed_stage(f"train RF {ticker}"):
+            rf = train_rf(X, y)
+            rf_path = MODEL_DIR / f"{ticker}_{frequency}_rf.pkl"
+            joblib.dump(rf, rf_path)
+            paths[f"{ticker}_rf"] = rf_path
+
+        with timed_stage(f"train XGB {ticker}"):
+            xgb = train_xgb(X, y)
+            xgb_path = MODEL_DIR / f"{ticker}_{frequency}_xgb.pkl"
+            joblib.dump(xgb, xgb_path)
+            paths[f"{ticker}_xgb"] = xgb_path
+
+        with timed_stage(f"train LSTM {ticker}"):
+            lstm = train_lstm(X, y)
+            lstm_path = MODEL_DIR / f"{ticker}_{frequency}_lstm.pkl"
+            joblib.dump(lstm, lstm_path)
+            paths[f"{ticker}_lstm"] = lstm_path
+
+    return paths


### PR DESCRIPTION
## Summary
- clean up notifier to remove Telegram support
- drop streamlit and telegram from requirements
- document the new pipeline in the README
- expose new helper utilities via `src/__init__`
- add modules for ticker selection, preprocessing, training, prediction and evaluation

## Testing
- `python -m py_compile src/*.py src/*/*.py`

------
https://chatgpt.com/codex/tasks/task_e_685602150540832ca8a7074bb846e81e