### PR TITLE
Add commit step to daily predictions

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -8,10 +8,23 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
       - uses: actions/setup-python@v5
         with:
           python-version: 3.11
       - run: pip install -r requirements.txt
       - run: python -m src.abt.build_abt
       - run: python -m src.predict
+      - name: Commit results
+        run: |
+          git config user.name "github-actions"
+          git config user.email "github-actions@github.com"
+          git add results/predictions.csv
+          if git diff --cached --quiet; then
+            echo "No changes to commit"
+          else
+            git commit -m "Update daily predictions"
+            git push
+          fi
       - run: python -m src.notify.notifier --message "Proceso diario completado"

--- a/README.md
+++ b/README.md
@@ -154,7 +154,9 @@ sequenceDiagram
 El repositorio incluye flujos de trabajo en `.github/workflows` que ejecutan el pipeline de manera programada. Ahora existen dos flujos principales:
 
 * `monthly.yml` realiza el entrenamiento completo una vez al mes.
-* `daily.yml` procesa los datos recientes y aplica los modelos para generar nuevas predicciones.
+* `daily.yml` procesa los datos recientes, aplica los modelos para generar nuevas
+  predicciones y luego guarda `results/predictions.csv` en el repositorio con
+  un commit automatico.
 
 ## Diagrama del pipeline automatizado
 


### PR DESCRIPTION
## Summary
- update daily workflow to commit prediction results
- document workflow change in README

## Testing
- `python -m py_compile src/predict.py`

------
https://chatgpt.com/codex/tasks/task_e_685609e6f278832c9f733b300d0ac767