### PR TITLE
Enable manual runs and add dataframe logging

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -2,7 +2,7 @@ name: Daily Processing
 on:
   schedule:
     - cron: '0 2 * * *'
-  workflow_dispatch:
+  workflow_dispatch: {}
 jobs:
   predict:
     runs-on: ubuntu-latest

--- a/.github/workflows/dashboard.yml
+++ b/.github/workflows/dashboard.yml
@@ -1,6 +1,6 @@
 name: Dashboard
 on:
-  workflow_dispatch:
+  workflow_dispatch: {}
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/monthly.yml
+++ b/.github/workflows/monthly.yml
@@ -2,7 +2,7 @@ name: Monthly Training
 on:
   schedule:
     - cron: '0 0 1 * *'
-  workflow_dispatch:
+  workflow_dispatch: {}
 jobs:
   train:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -97,21 +97,21 @@ del paquete para que puedas ejecutar el flujo sin complicaciones.
    ```bash
    python -m src.abt.build_abt
    ```
-   Esto baja datos historicos y agrega indicadores tecnicos. Antes de ejecutarlo puedes editar `config.yaml` para cambiar los tickers o el rango de fechas.
+   Esto baja datos historicos y agrega indicadores tecnicos. Antes de ejecutarlo puedes editar `config.yaml` para cambiar los tickers o el rango de fechas. Durante la ejecucion se imprimen las primeras filas de cada DataFrame y sus dimensiones para que puedas seguir el avance.
 
 3. **Entrenamiento**
    
    ```bash
    python -m src.training
    ```
-   Se generan varios modelos de ejemplo y se guardan en `models/`. Puedes revisar esos archivos para entender cómo mejorar la calidad de las predicciones.
+   Se generan varios modelos de ejemplo y se guardan en `models/`. Puedes revisar esos archivos para entender cómo mejorar la calidad de las predicciones. En pantalla verás un resumen de las matrices de entrenamiento usadas para cada ticker.
 
 4. **Prediccion**
    
    ```bash
    python -m src.predict
    ```
-   Se aplican los modelos guardados y se genera un archivo `predictions.csv` en la carpeta `results/`.
+   Se aplican los modelos guardados y se genera un archivo `predictions.csv` en la carpeta `results/`. El comando mostrará también un panorama del DataFrame usado para predecir.
 
 5. **Evaluacion**
    

--- a/src/abt/build_abt.py
+++ b/src/abt/build_abt.py
@@ -6,7 +6,7 @@ import pandas as pd
 import yfinance as yf
 import ta
 
-from ..utils import timed_stage
+from ..utils import timed_stage, log_df_details
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
@@ -22,6 +22,7 @@ def download_ticker(ticker: str, start: str) -> pd.DataFrame:
     """Download historical data for a single ticker."""
     with timed_stage(f"download {ticker}"):
         df = yf.download(ticker, start=start)
+    log_df_details(f"downloaded {ticker}", df)
     return df
 
 def enrich_indicators(df: pd.DataFrame) -> pd.DataFrame:
@@ -37,6 +38,7 @@ def enrich_indicators(df: pd.DataFrame) -> pd.DataFrame:
         except Exception:
             logger.exception("Failed to compute technical indicators")
             raise
+    log_df_details("with indicators", df)
     return df
 
 def build_abt() -> dict:
@@ -49,6 +51,7 @@ def build_abt() -> dict:
                 df = enrich_indicators(df)
                 out_file = DATA_DIR / f"{ticker}.csv"
                 df.to_csv(out_file)
+                log_df_details(f"saved {ticker}", df)
                 results[ticker] = out_file
         except Exception:
             logger.error("Failed to process %s", ticker)

--- a/src/predict.py
+++ b/src/predict.py
@@ -9,6 +9,8 @@ import pandas as pd
 
 from sklearn.metrics import mean_absolute_error, r2_score
 
+from .utils import log_df_details
+
 logger = logging.getLogger(__name__)
 
 CONFIG_PATH = Path(__file__).resolve().parents[1] / "config.yaml"
@@ -37,6 +39,7 @@ def run_predictions(models: Dict[str, Any], data: Dict[str, pd.DataFrame]) -> pd
         df = data.get(ticker)
         if df is None:
             continue
+        log_df_details(f"predict data {ticker}", df)
         X = df.drop(columns=["Close"], errors="ignore")
         y = df.get("Close")
         try:

--- a/src/preprocess.py
+++ b/src/preprocess.py
@@ -6,7 +6,7 @@ import pandas as pd
 import ta
 import yfinance as yf
 
-from .utils import timed_stage
+from .utils import timed_stage, log_df_details
 
 logger = logging.getLogger(__name__)
 
@@ -17,18 +17,21 @@ def extract_data(tickers: List[str], start: str) -> Dict[str, pd.DataFrame]:
     for t in tickers:
         with timed_stage(f"download {t}"):
             df = yf.download(t, start=start, progress=False)
-            data[t] = df
+        log_df_details(f"raw {t}", df)
+        data[t] = df
     return data
 
 
 def enrich_features(df: pd.DataFrame) -> pd.DataFrame:
     """Add common technical indicators."""
     if df.empty:
+        log_df_details("enrich empty", df)
         return df
     df = df.copy()
     df["rsi"] = ta.momentum.RSIIndicator(df["Close"]).rsi()
     df["sma_20"] = ta.trend.SMAIndicator(df["Close"], window=20).sma_indicator()
     df["sma_50"] = ta.trend.SMAIndicator(df["Close"], window=50).sma_indicator()
+    log_df_details("enriched", df)
     return df
 
 
@@ -37,5 +40,7 @@ def preprocess_data(data: Dict[str, pd.DataFrame]) -> Dict[str, pd.DataFrame]:
     processed = {}
     for t, df in data.items():
         with timed_stage(f"preprocess {t}"):
-            processed[t] = enrich_features(df)
+            processed_df = enrich_features(df)
+        log_df_details(f"processed {t}", processed_df)
+        processed[t] = processed_df
     return processed

--- a/src/training.py
+++ b/src/training.py
@@ -10,7 +10,7 @@ import pandas as pd
 from .models.lstm_model import train_lstm
 from .models.rf_model import train_rf
 from .models.xgb_model import train_xgb
-from .utils import timed_stage
+from .utils import timed_stage, log_df_details
 
 CONFIG_PATH = Path(__file__).resolve().parents[1] / "config.yaml"
 with open(CONFIG_PATH) as cfg_file:
@@ -29,8 +29,10 @@ def train_models(data: Dict[str, Union[pd.DataFrame, Path]], frequency: str = "d
     for ticker, df in data.items():
         if isinstance(df, (str, Path)):
             df = pd.read_csv(df)
+        log_df_details(f"training data {ticker}", df)
         X = df.drop(columns=["Close"], errors="ignore")
         y = df.get("Close")
+        log_df_details(f"features {ticker}", X)
 
         with timed_stage(f"train RF {ticker}"):
             try:

--- a/src/utils.py
+++ b/src/utils.py
@@ -1,6 +1,9 @@
 import logging
 import time
 from contextlib import contextmanager
+from typing import Optional
+
+import pandas as pd
 
 @contextmanager
 def timed_stage(name: str):
@@ -16,3 +19,16 @@ def timed_stage(name: str):
     finally:
         duration = time.perf_counter() - start
         logger.info("Finished %s in %.2f seconds", name, duration)
+
+
+def log_df_details(name: str, df: Optional[pd.DataFrame], head: int = 5) -> None:
+    """Log basic DataFrame information."""
+    logger = logging.getLogger(__name__)
+    if df is None:
+        logger.info("%s: DataFrame is None", name)
+        return
+    rows, cols = df.shape
+    logger.info("%s shape: %d rows, %d columns", name, rows, cols)
+    if not df.empty:
+        preview = df.head(head).to_string()
+        logger.info("%s head:\n%s", name, preview)


### PR DESCRIPTION
## Summary
- allow manual GitHub Action execution for daily, monthly and dashboard workflows
- show dataframe details during data extraction and model stages
- document the new console output in the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68562eee8af8832cb9b484173fa114bf