### PR TITLE
Fix config path for ABT build

### DIFF
--- a/src/abt/build_abt.py
+++ b/src/abt/build_abt.py
@@ -11,11 +11,13 @@ from ..utils import timed_stage, log_df_details
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
-CONFIG_PATH = Path(__file__).resolve().parents[1] / "config.yaml"
+# configuration lives at the project root two levels up from this file
+CONFIG_PATH = Path(__file__).resolve().parents[2] / "config.yaml"
 with open(CONFIG_PATH) as cfg_file:
     CONFIG = yaml.safe_load(cfg_file)
 
-DATA_DIR = Path(__file__).resolve().parents[1] / CONFIG.get("data_dir", "data")
+# store data in the directory defined in config at the project root
+DATA_DIR = Path(__file__).resolve().parents[2] / CONFIG.get("data_dir", "data")
 DATA_DIR.mkdir(exist_ok=True, parents=True)
 
 def download_ticker(ticker: str, start: str) -> pd.DataFrame:


### PR DESCRIPTION
## Summary
- fix build_abt config path

## Testing
- `python -m pip install --quiet -r requirements.txt` *(fails: Could not find pandas due to network)*
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68563241dbd8832c960e48bffb3ad88d