### PR TITLE
Add offline logging and silence yfinance errors

### DIFF
--- a/src/predict.py
+++ b/src/predict.py
@@ -9,7 +9,7 @@ import pandas as pd
 
 from sklearn.metrics import mean_absolute_error, r2_score
 
-from .utils import log_df_details
+from .utils import log_df_details, log_offline_mode
 
 logger = logging.getLogger(__name__)
 
@@ -55,6 +55,7 @@ def run_predictions(models: Dict[str, Any], data: Dict[str, pd.DataFrame]) -> pd
     out_file = RESULTS_DIR / "predictions.csv"
     result_df.to_csv(out_file, index=False)
     logger.info("Saved predictions to %s", out_file)
+    log_offline_mode("prediction")
     return result_df
 
 

--- a/src/preprocess.py
+++ b/src/preprocess.py
@@ -6,9 +6,15 @@ import pandas as pd
 import ta
 import yfinance as yf
 
-from .utils import timed_stage, log_df_details
+from .utils import (
+    timed_stage,
+    log_df_details,
+    generate_sample_data,
+    log_offline_mode,
+)
 
 logger = logging.getLogger(__name__)
+logging.getLogger("yfinance").setLevel(logging.CRITICAL)
 
 
 def extract_data(tickers: List[str], start: str) -> Dict[str, pd.DataFrame]:
@@ -16,9 +22,17 @@ def extract_data(tickers: List[str], start: str) -> Dict[str, pd.DataFrame]:
     data = {}
     for t in tickers:
         with timed_stage(f"download {t}"):
-            df = yf.download(t, start=start, progress=False)
+            try:
+                df = yf.download(t, start=start, progress=False)
+            except Exception:
+                logger.error("Failed to download %s, using sample", t)
+                df = generate_sample_data(start)
+        if df.empty:
+            logger.warning("%s download empty, using sample", t)
+            df = generate_sample_data(start)
         log_df_details(f"raw {t}", df)
         data[t] = df
+    log_offline_mode("extract_data")
     return data
 
 
@@ -43,4 +57,5 @@ def preprocess_data(data: Dict[str, pd.DataFrame]) -> Dict[str, pd.DataFrame]:
             processed_df = enrich_features(df)
         log_df_details(f"processed {t}", processed_df)
         processed[t] = processed_df
+    log_offline_mode("preprocess_data")
     return processed

--- a/src/training.py
+++ b/src/training.py
@@ -10,7 +10,7 @@ import pandas as pd
 from .models.lstm_model import train_lstm
 from .models.rf_model import train_rf
 from .models.xgb_model import train_xgb
-from .utils import timed_stage, log_df_details
+from .utils import timed_stage, log_df_details, log_offline_mode
 
 CONFIG_PATH = Path(__file__).resolve().parents[1] / "config.yaml"
 with open(CONFIG_PATH) as cfg_file:
@@ -70,6 +70,7 @@ def train_models(data: Dict[str, Union[pd.DataFrame, Path]], frequency: str = "d
             except Exception:
                 logger.error("Failed LSTM training for %s", ticker)
 
+    log_offline_mode("training")
     return paths
 
 


### PR DESCRIPTION
## Summary
- track usage of generated sample data with a global flag in utils
- suppress noisy yfinance logs
- report sample data usage after build, preprocessing, training and prediction stages

## Testing
- `python -m src.abt.build_abt` *(fails: ModuleNotFoundError: No module named 'pandas')*
- `pip install pandas` *(fails: Tunnel connection failed)*

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_685634cbe750832ca6c271b548f55428