### PR TITLE
Ensure models are versioned monthly

### DIFF
--- a/.github/workflows/monthly.yml
+++ b/.github/workflows/monthly.yml
@@ -13,6 +13,17 @@ jobs:
           python-version: 3.11
       - run: pip install -r requirements.txt
       - run: python -m src.training
+      - name: Commit trained models
+        run: |
+          git config user.name "github-actions"
+          git config user.email "github-actions@github.com"
+          git add models/*.pkl
+          if git diff --cached --quiet; then
+            echo "No model changes to commit"
+          else
+            git commit -m "Update monthly models"
+            git push
+          fi
       - run: python -m src.predict
       - run: python -m src.portfolio.optimize
       - run: python -m src.notify.notifier --message "Proceso mensual completado"

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+# Ignore generated data
+data/
+
+# Keep only predictions CSV from results
+results/*
+!results/predictions.csv
+
+# Byte-compiled / cache files
+__pycache__/
+*.py[cod]

--- a/README.md
+++ b/README.md
@@ -74,7 +74,8 @@ La carpeta `src` contiene todas las utilidades. Algunos scripts son simples plan
 * `abt/` incluye la construcción de la "Analytic Base Table". Aquí se descargan y
   enriquecen los datos diarios.
 * `models/` contiene ejemplos de modelos de machine learning listos para usar o
-  para que los sustituyas por los tuyos.
+  para que los sustituyas por los tuyos. En esta carpeta se almacenan tambien los
+  modelos entrenados mensualmente que se versionan en el repositorio.
 * `portfolio/` alberga herramientas para backtesting y optimización de cartera.
 * `notify/` muestra cómo enviar un correo o mensaje una vez que tienes nuevos
   resultados.
@@ -155,12 +156,10 @@ sequenceDiagram
 
 ## Automatizacion
 
-El repositorio incluye flujos de trabajo en `.github/workflows` que ejecutan el pipeline de manera programada. Ahora existen dos flujos principales:
+El repositorio incluye flujos de trabajo en `.github/workflows` que ejecutan el pipeline de forma programada. Estos flujos se complementan de la siguiente manera:
 
-* `monthly.yml` realiza el entrenamiento completo una vez al mes.
-* `daily.yml` procesa los datos recientes, aplica los modelos para generar nuevas
-  predicciones y luego guarda `results/predictions.csv` en el repositorio con
-  un commit automatico.
+* `monthly.yml` realiza el entrenamiento completo una vez al mes y guarda los modelos resultantes en la carpeta `models/`. Tras entrenar se realiza un commit automatico con cualquier archivo `*.pkl` nuevo o actualizado para mantener la version mas reciente en el repositorio.
+* `daily.yml` procesa los datos nuevos y aplica **unicamente** los modelos almacenados en `models/`; no ejecuta ninguna fase de entrenamiento. Las predicciones se escriben en `results/predictions.csv` y se suben mediante un commit automatico cuando existen cambios.
 
 ## Diagrama del pipeline automatizado
 

--- a/src/predict.py
+++ b/src/predict.py
@@ -29,6 +29,10 @@ def load_models(model_dir: Path) -> Dict[str, Any]:
             models[file.stem] = joblib.load(file)
         except Exception:
             logger.error("Failed to load model %s", file)
+    if not models:
+        raise FileNotFoundError(
+            f"No trained models found in {model_dir}. Run the monthly training first."
+        )
     return models
 
 


### PR DESCRIPTION
## Summary
- ignore local data and only keep prediction CSV
- store trained models in `models/` and keep the folder in git
- push new models after monthly training workflow completes
- prevent predictions from running when no models exist
- document the new automation flow in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6856382e8940832ca63ab46f99a9acf0