### PR TITLE
Fix data loading for model training

### DIFF
--- a/src/abt/build_abt.py
+++ b/src/abt/build_abt.py
@@ -96,7 +96,8 @@ def build_abt() -> dict:
                 df = download_ticker(ticker, CONFIG["start_date"])
                 df = enrich_indicators(df)
                 out_file = DATA_DIR / f"{ticker}.csv"
-                df.to_csv(out_file)
+                df.index.name = "Date"
+                df.to_csv(out_file, index_label="Date")
                 log_df_details(f"saved {ticker}", df)
                 results[ticker] = out_file
         except Exception:

--- a/src/predict.py
+++ b/src/predict.py
@@ -67,6 +67,6 @@ if __name__ == "__main__":
     from .abt.build_abt import build_abt
 
     data_paths = build_abt()
-    data = {t: pd.read_csv(p) for t, p in data_paths.items()}
+    data = {t: pd.read_csv(p, index_col=0, parse_dates=True) for t, p in data_paths.items()}
     models = load_models(MODEL_DIR)
     run_predictions(models, data)

--- a/src/training.py
+++ b/src/training.py
@@ -28,7 +28,7 @@ def train_models(data: Dict[str, Union[pd.DataFrame, Path]], frequency: str = "d
     paths = {}
     for ticker, df in data.items():
         if isinstance(df, (str, Path)):
-            df = pd.read_csv(df)
+            df = pd.read_csv(df, index_col=0, parse_dates=True)
         log_df_details(f"training data {ticker}", df)
         X = df.drop(columns=["Close"], errors="ignore")
         y = df.get("Close")
@@ -78,5 +78,5 @@ if __name__ == "__main__":
     from .abt.build_abt import build_abt
 
     data_paths = build_abt()
-    data = {t: pd.read_csv(p) for t, p in data_paths.items()}
+    data = {t: pd.read_csv(p, index_col=0, parse_dates=True) for t, p in data_paths.items()}
     train_models(data)


### PR DESCRIPTION
## Summary
- preserve Date index when saving ABT
- read CSVs with index and parsed dates in training and prediction

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68563d7eca50832cb3a3117a9cdad266