### PR TITLE
Fix missing dependency for data fetch

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ schedule==1.2.1
 PyYAML==6.0.1
 joblib==1.3.2
 requests-cache==1.2.0
+pandas-datareader==0.10.0


### PR DESCRIPTION
## Summary
- include `pandas-datareader` in requirements

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685642247104832cb0d777e72187af65