### PR TITLE
Fix yfinance session conflict

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ schedule==1.2.1
 PyYAML==6.0.1
 joblib==1.3.2
 requests-cache==1.2.0
+pandas-datareader==0.10.0

--- a/src/abt/build_abt.py
+++ b/src/abt/build_abt.py
@@ -32,9 +32,10 @@ DATA_DIR.mkdir(exist_ok=True, parents=True)
 
 CACHE_EXPIRE = 60 * 60  # 1 h
 
-session = requests_cache.CachedSession(
-    "yf_cache", expire_after=CACHE_EXPIRE
-)
+# Install a global cache for all requests instead of passing a session to
+# yfinance. The library now manages its own session, so this avoids
+# compatibility issues and still provides caching.
+requests_cache.install_cache("yf_cache", expire_after=CACHE_EXPIRE)
 
 
 def _internet_ok(host="query1.finance.yahoo.com", port=443, timeout=3):
@@ -46,11 +47,11 @@ def _internet_ok(host="query1.finance.yahoo.com", port=443, timeout=3):
 
 
 def _download_yahoo(ticker, period, interval):
+    """Download data using yfinance without passing a custom session."""
     return yf.download(
         ticker,
         period=period,
         interval=interval,
-        session=session,
         progress=False,
         threads=False,
     )


### PR DESCRIPTION
## Summary
- update ABT builder to use global requests cache instead of a custom session
- remove incompatible session argument from yfinance downloads

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685642247104832cb0d777e72187af65