### PR TITLE
Improve evaluation metrics and store results

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@ data/
 # Keep only predictions CSV from results
 results/*
 !results/predictions.csv
+!results/metrics/
+!results/metrics/**
 
 # Byte-compiled / cache files
 __pycache__/

--- a/README.md
+++ b/README.md
@@ -110,6 +110,9 @@ del paquete para que puedas ejecutar el flujo sin complicaciones.
    hiperparámetros para que el proceso sea rápido. Puedes ampliar la grilla de
    parámetros en `src/training.py` si necesitas ajustes más robustos. En pantalla
    verás un resumen de las matrices de entrenamiento usadas para cada ticker.
+   Tras entrenar se calculan métricas y se guardan en la carpeta indicada por
+   `evaluation_dir`. Cada archivo lleva la fecha del entrenamiento y las
+   métricas también se imprimen en los logs.
 
 4. **Prediccion**
    
@@ -123,7 +126,8 @@ del paquete para que puedas ejecutar el flujo sin complicaciones.
    ```bash
    python -m src.evaluation
    ```
-   Compara predicciones con valores reales y emite métricas simples como MAE y R2. Sirve para saber si los modelos deben reentrenarse.
+   Compara predicciones con valores reales y emite varias métricas (MAE, MSE,
+   RMSE, MAPE, R2 y EVS). Sirve para decidir si los modelos deben reentrenarse.
 
 6. **Optimizacion de portafolio**
    

--- a/config.yaml
+++ b/config.yaml
@@ -10,3 +10,4 @@ prediction_horizon: 5
 risk_free_rate: 0.015
 data_dir: "data"
 model_dir: "models"
+evaluation_dir: "results/metrics"

--- a/src/abt/build_abt.py
+++ b/src/abt/build_abt.py
@@ -100,6 +100,10 @@ def download_ticker(
             logger.warning("Todo falló. Generando datos de ejemplo.")
             df = generate_sample_data(start_dt)
 
+        if isinstance(df.columns, pd.MultiIndex):
+            df = df.copy()
+            df.columns = df.columns.get_level_values(0)
+
     log_df_details(f"downloaded {ticker}", df)
     return df
 

--- a/src/evaluation.py
+++ b/src/evaluation.py
@@ -3,16 +3,33 @@ import logging
 from typing import Sequence
 
 import numpy as np
-from sklearn.metrics import mean_absolute_error, r2_score
+from sklearn.metrics import (
+    mean_absolute_error,
+    mean_squared_error,
+    mean_absolute_percentage_error,
+    explained_variance_score,
+    r2_score,
+)
 
 logger = logging.getLogger(__name__)
 
 
 def evaluate_predictions(y_true: Sequence[float], y_pred: Sequence[float]) -> dict:
-    """Return basic regression metrics."""
+    """Return an expanded set of regression metrics."""
     mae = mean_absolute_error(y_true, y_pred)
+    mse = mean_squared_error(y_true, y_pred)
+    rmse = mean_squared_error(y_true, y_pred, squared=False)
+    mape = mean_absolute_percentage_error(y_true, y_pred)
     r2 = r2_score(y_true, y_pred)
-    return {"MAE": mae, "R2": r2}
+    evs = explained_variance_score(y_true, y_pred)
+    return {
+        "MAE": mae,
+        "MSE": mse,
+        "RMSE": rmse,
+        "MAPE": mape,
+        "R2": r2,
+        "EVS": evs,
+    }
 
 
 def detect_drift(prev: Sequence[float], curr: Sequence[float], threshold: float = 0.1) -> bool:

--- a/src/training.py
+++ b/src/training.py
@@ -11,6 +11,9 @@ from .models.lstm_model import train_lstm
 from .models.rf_model import train_rf
 from .models.xgb_model import train_xgb
 from .utils import timed_stage, log_df_details, log_offline_mode
+from .evaluation import evaluate_predictions
+
+RUN_TIMESTAMP = pd.Timestamp.now(tz="UTC").isoformat()
 
 CONFIG_PATH = Path(__file__).resolve().parents[1] / "config.yaml"
 with open(CONFIG_PATH) as cfg_file:
@@ -21,11 +24,18 @@ logger = logging.getLogger(__name__)
 
 MODEL_DIR = Path(__file__).resolve().parents[1] / CONFIG.get("model_dir", "models")
 MODEL_DIR.mkdir(exist_ok=True, parents=True)
+EVAL_DIR = Path(__file__).resolve().parents[1] / CONFIG.get(
+    "evaluation_dir", "results/metrics"
+)
+EVAL_DIR.mkdir(exist_ok=True, parents=True)
 
 
-def train_models(data: Dict[str, Union[pd.DataFrame, Path]], frequency: str = "daily") -> Dict[str, Path]:
-    """Train basic models and persist them to disk."""
+def train_models(
+    data: Dict[str, Union[pd.DataFrame, Path]], frequency: str = "daily"
+) -> Dict[str, Path]:
+    """Train basic models, evaluate them and persist both models and metrics."""
     paths = {}
+    metrics_rows = []
     for ticker, df in data.items():
         if isinstance(df, (str, Path)):
             df = pd.read_csv(df, index_col=0, parse_dates=True)
@@ -44,6 +54,14 @@ def train_models(data: Dict[str, Union[pd.DataFrame, Path]], frequency: str = "d
                 rf_path = MODEL_DIR / f"{ticker}_{frequency}_rf.pkl"
                 joblib.dump(rf, rf_path)
                 paths[f"{ticker}_rf"] = rf_path
+                try:
+                    preds = rf.predict(X)
+                    metrics = evaluate_predictions(y, preds)
+                    metrics_row = {"model": f"{ticker}_rf", **metrics, "run_date": RUN_TIMESTAMP}
+                    metrics_rows.append(metrics_row)
+                    logger.info("RF metrics %s", metrics_row)
+                except Exception:
+                    logger.error("Failed RF evaluation for %s", ticker)
             except Exception:
                 logger.error("Failed RF training for %s", ticker)
 
@@ -57,6 +75,14 @@ def train_models(data: Dict[str, Union[pd.DataFrame, Path]], frequency: str = "d
                 xgb_path = MODEL_DIR / f"{ticker}_{frequency}_xgb.pkl"
                 joblib.dump(xgb, xgb_path)
                 paths[f"{ticker}_xgb"] = xgb_path
+                try:
+                    preds = xgb.predict(X)
+                    metrics = evaluate_predictions(y, preds)
+                    metrics_row = {"model": f"{ticker}_xgb", **metrics, "run_date": RUN_TIMESTAMP}
+                    metrics_rows.append(metrics_row)
+                    logger.info("XGB metrics %s", metrics_row)
+                except Exception:
+                    logger.error("Failed XGB evaluation for %s", ticker)
             except Exception:
                 logger.error("Failed XGB training for %s", ticker)
 
@@ -67,8 +93,24 @@ def train_models(data: Dict[str, Union[pd.DataFrame, Path]], frequency: str = "d
                 lstm_path = MODEL_DIR / f"{ticker}_{frequency}_lstm.pkl"
                 joblib.dump(lstm, lstm_path)
                 paths[f"{ticker}_lstm"] = lstm_path
+                try:
+                    preds = lstm.predict(X)
+                    preds = preds.flatten() if hasattr(preds, "flatten") else preds
+                    metrics = evaluate_predictions(y, preds)
+                    metrics_row = {"model": f"{ticker}_lstm", **metrics, "run_date": RUN_TIMESTAMP}
+                    metrics_rows.append(metrics_row)
+                    logger.info("LSTM metrics %s", metrics_row)
+                except Exception:
+                    logger.error("Failed LSTM evaluation for %s", ticker)
             except Exception:
                 logger.error("Failed LSTM training for %s", ticker)
+
+    if metrics_rows:
+        metrics_df = pd.DataFrame(metrics_rows)
+        metrics_file = EVAL_DIR / f"metrics_{frequency}_{RUN_TIMESTAMP[:10]}.csv"
+        metrics_df.to_csv(metrics_file, index=False)
+        logger.info("Saved evaluation metrics to %s", metrics_file)
+        logger.info("Metrics summary:\n%s", metrics_df)
 
     log_offline_mode("training")
     return paths


### PR DESCRIPTION
## Summary
- extend evaluation metrics to include MSE, RMSE, MAPE and explained variance
- add config option to specify `evaluation_dir`
- during training store evaluation metrics for each model
- include run timestamp in saved metrics and log them
- keep metrics folder in version control
- handle multi-indexed price data in ABT builder

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68564a6e856c832cb678ea5ffe4da473