### PR TITLE
Combine ETFs into single ABT

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -11,3 +11,10 @@ risk_free_rate: 0.015
 data_dir: "data"
 model_dir: "models"
 evaluation_dir: "results/metrics"
+target_cols:
+  SPY: Close
+  QQQ: "Adj Close"
+  IEF: Close
+  GLD: Close
+  EEM: Close
+  VNQ: Close


### PR DESCRIPTION
## Summary
- build a single ETF dataset by concatenating ticker data
- allow training with combined dataset and per-ticker target columns
- store per-ticker target settings in `config.yaml`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68564ef23e8c832c835c939b61bb911c