### PR TITLE
Fix start date usage and add rolling CV

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,10 +105,10 @@ del paquete para que puedas ejecutar el flujo sin complicaciones.
    ```bash
    python -m src.training
    ```
-   Se generan varios modelos de ejemplo y se guardan en `models/`. Cada
-   entrenamiento ejecuta una validación cruzada básica con solo un par de
-   hiperparámetros para que el proceso sea rápido. Puedes ampliar la grilla de
-   parámetros en `src/training.py` si necesitas ajustes más robustos. En pantalla
+    Se generan varios modelos de ejemplo y se guardan en `models/`. Cada
+    entrenamiento utiliza los últimos 6 meses de datos y aplica validación
+    cruzada temporal con ventanas de 60 días para predecir el día siguiente.
+    Puedes ampliar la grilla de parámetros en `src/training.py` si necesitas ajustes más robustos. En pantalla
    verás un resumen de las matrices de entrenamiento usadas para cada ticker.
    Tras entrenar se calculan métricas y se guardan en la carpeta indicada por
    `evaluation_dir`. Cada archivo lleva la fecha del entrenamiento y las

--- a/src/models/lightgbm_model.py
+++ b/src/models/lightgbm_model.py
@@ -1,10 +1,10 @@
 """LightGBM utilities with simple cross-validation support."""
 import logging
 import time
-from typing import Any, Dict, Sequence
+from typing import Any, Dict, Sequence, Union
 
 from lightgbm import LGBMRegressor
-from sklearn.model_selection import GridSearchCV, TimeSeriesSplit
+from sklearn.model_selection import GridSearchCV, TimeSeriesSplit, BaseCrossValidator
 
 logger = logging.getLogger(__name__)
 
@@ -13,7 +13,7 @@ def train_lgbm(
     X_train,
     y_train,
     param_grid: Dict[str, Sequence] | None = None,
-    cv: int = 3,
+    cv: Union[int, BaseCrossValidator] = 3,
     **kwargs,
 ) -> Any:
     """Train a LightGBM model with optional cross-validation."""
@@ -28,7 +28,7 @@ def train_lgbm(
 
     try:
         base_model = LGBMRegressor(random_state=42, **kwargs)
-        splitter = TimeSeriesSplit(n_splits=cv)
+        splitter = TimeSeriesSplit(n_splits=cv) if isinstance(cv, int) else cv
         search = GridSearchCV(
             base_model,
             param_grid=param_grid,

--- a/src/models/linear_model.py
+++ b/src/models/linear_model.py
@@ -1,22 +1,27 @@
 """Simple linear regression utilities."""
 import logging
 import time
-from typing import Any
+from typing import Any, Union
 
 from sklearn.linear_model import LinearRegression
-from sklearn.model_selection import TimeSeriesSplit, cross_val_score
+from sklearn.model_selection import TimeSeriesSplit, cross_val_score, BaseCrossValidator
 
 logger = logging.getLogger(__name__)
 
 
-def train_linear(X_train, y_train, cv: int = 3, **kwargs) -> Any:
+def train_linear(
+    X_train,
+    y_train,
+    cv: Union[int, BaseCrossValidator] = 3,
+    **kwargs,
+) -> Any:
     """Train a linear regression model with basic cross-validation."""
     start = time.perf_counter()
     logger.info("Training Linear Regression model")
 
     try:
         model = LinearRegression(**kwargs)
-        splitter = TimeSeriesSplit(n_splits=cv)
+        splitter = TimeSeriesSplit(n_splits=cv) if isinstance(cv, int) else cv
         scores = cross_val_score(
             model,
             X_train,

--- a/src/models/lstm_model.py
+++ b/src/models/lstm_model.py
@@ -1,12 +1,12 @@
 """Utility functions to train and use an LSTM model with simple CV."""
 import logging
 import time
-from typing import Any, Dict, Sequence
+from typing import Any, Dict, Sequence, Union
 
 import numpy as np
 from tensorflow import keras
 from tensorflow.keras import layers
-from sklearn.model_selection import TimeSeriesSplit
+from sklearn.model_selection import TimeSeriesSplit, BaseCrossValidator
 
 logger = logging.getLogger(__name__)
 
@@ -15,7 +15,7 @@ def train_lstm(
     X_train,
     y_train,
     param_grid: Dict[str, Sequence] | None = None,
-    cv: int = 3,
+    cv: Union[int, BaseCrossValidator] = 3,
     **kwargs,
 ) -> Any:
     """Train a simple LSTM using manual cross-validation."""
@@ -33,7 +33,7 @@ def train_lstm(
     best_score = float("inf")
     best_params = {"units": 16, "epochs": 2}
 
-    splitter = TimeSeriesSplit(n_splits=cv)
+    splitter = TimeSeriesSplit(n_splits=cv) if isinstance(cv, int) else cv
 
     try:
         for units in param_grid.get("units", [16]):

--- a/src/models/rf_model.py
+++ b/src/models/rf_model.py
@@ -1,10 +1,10 @@
 """Random Forest utilities with simple cross-validation support."""
 import logging
 import time
-from typing import Any, Dict, Sequence
+from typing import Any, Dict, Sequence, Union
 
 from sklearn.ensemble import RandomForestRegressor
-from sklearn.model_selection import GridSearchCV, TimeSeriesSplit
+from sklearn.model_selection import GridSearchCV, TimeSeriesSplit, BaseCrossValidator
 
 logger = logging.getLogger(__name__)
 
@@ -13,7 +13,7 @@ def train_rf(
     X_train,
     y_train,
     param_grid: Dict[str, Sequence] | None = None,
-    cv: int = 3,
+    cv: Union[int, BaseCrossValidator] = 3,
     **kwargs,
 ) -> Any:
     """Train a Random Forest with optional cross-validation.
@@ -42,7 +42,7 @@ def train_rf(
 
     try:
         base_model = RandomForestRegressor(random_state=42, **kwargs)
-        splitter = TimeSeriesSplit(n_splits=cv)
+        splitter = TimeSeriesSplit(n_splits=cv) if isinstance(cv, int) else cv
         search = GridSearchCV(
             base_model,
             param_grid=param_grid,

--- a/src/models/xgb_model.py
+++ b/src/models/xgb_model.py
@@ -1,10 +1,10 @@
 """XGBoost model utilities with simple cross-validation support."""
 import logging
 import time
-from typing import Any, Dict, Sequence
+from typing import Any, Dict, Sequence, Union
 
 from xgboost import XGBRegressor
-from sklearn.model_selection import GridSearchCV, TimeSeriesSplit
+from sklearn.model_selection import GridSearchCV, TimeSeriesSplit, BaseCrossValidator
 
 logger = logging.getLogger(__name__)
 
@@ -13,7 +13,7 @@ def train_xgb(
     X_train,
     y_train,
     param_grid: Dict[str, Sequence] | None = None,
-    cv: int = 3,
+    cv: Union[int, BaseCrossValidator] = 3,
     **kwargs,
 ) -> Any:
     """Train an XGBoost model with optional cross-validation."""
@@ -29,7 +29,7 @@ def train_xgb(
 
     try:
         base_model = XGBRegressor(random_state=42, verbosity=0, **kwargs)
-        splitter = TimeSeriesSplit(n_splits=cv)
+        splitter = TimeSeriesSplit(n_splits=cv) if isinstance(cv, int) else cv
         search = GridSearchCV(
             base_model,
             param_grid=param_grid,

--- a/src/selection.py
+++ b/src/selection.py
@@ -1,6 +1,6 @@
 """Stock selection utilities."""
 import logging
-from datetime import datetime, timedelta
+from datetime import datetime
 from typing import List
 
 import pandas as pd
@@ -47,3 +47,17 @@ def select_tickers(candidates: List[str], end_date: str) -> List[str]:
     selection = top_volume + most_stable + biggest_losers
     logger.info("Selected tickers: %s", selection)
     return selection
+
+
+if __name__ == "__main__":
+    import yaml
+    from pathlib import Path
+
+    CONFIG_PATH = Path(__file__).resolve().parents[1] / "config.yaml"
+    with open(CONFIG_PATH) as cfg_file:
+        config = yaml.safe_load(cfg_file)
+
+    tickers = config.get("etfs", [])
+    today = datetime.today().strftime("%Y-%m-%d")
+    selected = select_tickers(tickers, today)
+    print("Selected tickers:", ", ".join(selected))


### PR DESCRIPTION
## Summary
- use the `start_date` from `config.yaml` when downloading data
- make `selection.py` executable from the command line
- adjust training to use the last 6 months with 60‑day rolling CV
- allow models to accept custom cross validators
- document the new training strategy in the README

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68570b408d84832c91ecb900bc6c44c6