### PR TITLE
Add weekly ABT workflow and quarterly training

### DIFF
--- a/.github/workflows/monthly.yml
+++ b/.github/workflows/monthly.yml
@@ -3,7 +3,7 @@ permissions:
   contents: write
 on:
   schedule:
-    - cron: '0 0 1 * *'
+    - cron: '0 0 1 */3 *'
   workflow_dispatch: {}
 jobs:
   train:

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -1,0 +1,34 @@
+name: Weekly ABT
+permissions:
+  contents: write
+on:
+  schedule:
+    - cron: '0 3 * * 1'
+  workflow_dispatch: {}
+jobs:
+  build_weekly:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          persist-credentials: true
+      - uses: actions/setup-python@v5
+        with:
+          python-version: 3.11
+      - uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements*.txt') }}
+      - name: Instalar dependencias
+        run: |
+          pip install --upgrade pip
+          pip install yfinance==0.2.61 ta==0.11.0 requests-cache==1.2.0 pandas>=2.2
+          pip install -r requirements.txt
+      - run: python -m src.abt.build_abt --weekly
+      - name: Upload weekly ABT
+        uses: actions/upload-artifact@v4
+        with:
+          name: weekly-abt
+          path: data/*_weekly.csv
+      - run: python -m src.notify.notifier --message "Proceso semanal completado"

--- a/README.md
+++ b/README.md
@@ -162,7 +162,8 @@ sequenceDiagram
 
 El repositorio incluye flujos de trabajo en `.github/workflows` que ejecutan el pipeline de forma programada. Estos flujos se complementan de la siguiente manera:
 
-* `monthly.yml` realiza el entrenamiento completo una vez al mes y guarda los modelos resultantes en la carpeta `models/`. Tras entrenar se realiza un commit automatico con cualquier archivo `*.pkl` nuevo o actualizado para mantener la version mas reciente en el repositorio.
+* `monthly.yml` ejecuta el entrenamiento completo cada tres meses y guarda los modelos resultantes en la carpeta `models/`. Tras entrenar se realiza un commit automatico con cualquier archivo `*.pkl` nuevo o actualizado para mantener la version mas reciente en el repositorio.
+* `weekly.yml` genera la version agregada semanalmente del ABT. Se ejecuta cada lunes y sube los archivos como artefactos.
 * `daily.yml` procesa los datos nuevos y aplica **unicamente** los modelos almacenados en `models/`; no ejecuta ninguna fase de entrenamiento. Las predicciones se escriben en `results/predictions.csv` y se suben mediante un commit automatico cuando existen cambios.
 
 Para que estos flujos puedan subir cambios al repositorio asegúrate de que el `GITHUB_TOKEN` tenga permisos de escritura. Los archivos YAML incluyen `permissions: contents: write`, con lo que el token integrado bastará en la mayoría de los repositorios. Si usas un fork o tu `GITHUB_TOKEN` es de solo lectura, crea un *Personal Access Token* y guárdalo como `GH_PAT`. Luego modifica los workflows para utilizar dicho token al hacer `git push`.

--- a/src/abt/__init__.py
+++ b/src/abt/__init__.py
@@ -1,0 +1,3 @@
+from .build_abt import build_abt, build_weekly_abt
+
+__all__ = ["build_abt", "build_weekly_abt"]


### PR DESCRIPTION
## Summary
- schedule training every three months
- add workflow to build weekly aggregated data
- document new schedules

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68579996d4a0832cbb5d48bc409f8dfc