### PR TITLE
Handle NaNs in training data

### DIFF
--- a/src/evaluation.py
+++ b/src/evaluation.py
@@ -9,6 +9,7 @@ from sklearn.metrics import (
     mean_absolute_percentage_error,
     explained_variance_score,
     r2_score,
+    root_mean_squared_error,
 )
 
 logger = logging.getLogger(__name__)
@@ -18,11 +19,11 @@ def evaluate_predictions(y_true: Sequence[float], y_pred: Sequence[float]) -> di
     """Return an expanded set of regression metrics."""
     mae = mean_absolute_error(y_true, y_pred)
     mse = mean_squared_error(y_true, y_pred)
-    rmse = mean_squared_error(y_true, y_pred, squared=False)
+    rmse = root_mean_squared_error(y_true, y_pred)
     mape = mean_absolute_percentage_error(y_true, y_pred)
     r2 = r2_score(y_true, y_pred)
     evs = explained_variance_score(y_true, y_pred)
-    return {
+    metrics = {
         "MAE": mae,
         "MSE": mse,
         "RMSE": rmse,
@@ -30,6 +31,7 @@ def evaluate_predictions(y_true: Sequence[float], y_pred: Sequence[float]) -> di
         "R2": r2,
         "EVS": evs,
     }
+    return {k: round(v, 4) for k, v in metrics.items()}
 
 
 def detect_drift(prev: Sequence[float], curr: Sequence[float], threshold: float = 0.1) -> bool:

--- a/src/features.py
+++ b/src/features.py
@@ -29,7 +29,7 @@ def _add_advanced_indicators(df: pd.DataFrame) -> pd.DataFrame:
     df["bb_bbl"] = bb.bollinger_lband()
     df["bb_width"] = (df["bb_bbh"] - df["bb_bbl"]) / df["bb_bbm"]
 
-    stoch = ta.momentum.StochOscillator(df["High"], df["Low"], df["Close"])
+    stoch = ta.momentum.StochasticOscillator(df["High"], df["Low"], df["Close"])
     df["stoch"] = stoch.stoch()
     df["stoch_signal"] = stoch.stoch_signal()
 

--- a/src/models/lightgbm_model.py
+++ b/src/models/lightgbm_model.py
@@ -27,7 +27,7 @@ def train_lgbm(
         }
 
     try:
-        base_model = LGBMRegressor(random_state=42, **kwargs)
+        base_model = LGBMRegressor(random_state=42, verbosity=-1, **kwargs)
         splitter = TimeSeriesSplit(n_splits=cv) if isinstance(cv, int) else cv
         search = GridSearchCV(
             base_model,

--- a/src/predict.py
+++ b/src/predict.py
@@ -1,6 +1,7 @@
 """Apply trained models to new data and store predictions."""
 import logging
 import yaml
+import numpy as np
 from pathlib import Path
 from typing import Dict, Any
 
@@ -52,7 +53,15 @@ def run_predictions(models: Dict[str, Any], data: Dict[str, pd.DataFrame]) -> pd
                 continue
             mae = mean_absolute_error(y, preds)
             r2 = r2_score(y, preds)
-            rows.append({"ticker": ticker, "mae": mae, "r2": r2, "actual": y.iloc[-1], "pred": preds[-1]})
+            pred_array = np.asarray(preds).reshape(-1)
+            last_pred = pred_array[-1] if pred_array.size else None
+            rows.append({
+                "ticker": ticker,
+                "mae": mae,
+                "r2": r2,
+                "actual": y.iloc[-1],
+                "pred": last_pred,
+            })
         except Exception:
             logger.error("Prediction failed for %s", name)
     result_df = pd.DataFrame(rows)

--- a/src/training.py
+++ b/src/training.py
@@ -63,8 +63,11 @@ def train_models(
         start_cv = end_dt - pd.DateOffset(months=6)
         df_recent = df.loc[df.index >= start_cv]
 
-        X = df_recent.drop(columns=[target_col], errors="ignore")
-        y = df_recent.get(target_col)
+        df_recent = df_recent.copy()
+        df_recent["target"] = df_recent[target_col].shift(-1)
+        df_recent.dropna(inplace=True)
+        X = df_recent.drop(columns=[target_col, "target"], errors="ignore")
+        y = df_recent["target"]
         log_df_details(f"features {ticker}", X)
 
         n_samples = len(df_recent)

--- a/src/utils.py
+++ b/src/utils.py
@@ -16,6 +16,7 @@ def timed_stage(name: str):
     """Context manager to log start/end time of a stage."""
     logger = logging.getLogger(__name__)
     start = time.perf_counter()
+    logger.info("-" * 40)
     logger.info("Starting %s", name)
     try:
         yield
@@ -25,6 +26,7 @@ def timed_stage(name: str):
     finally:
         duration = time.perf_counter() - start
         logger.info("Finished %s in %.2f seconds", name, duration)
+        logger.info("-" * 40)
 
 
 def log_df_details(name: str, df: Optional[pd.DataFrame], head: int = 5) -> None:


### PR DESCRIPTION
## Summary
- drop any rows containing NaNs when preparing features for training
- apply one-step target shift so models predict next observation
- round evaluation metrics and use `root_mean_squared_error`
- capture latest prediction robustly and suppress LightGBM logs
- add separator lines between timed stages
- fix technical indicator class name

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685f6becc2f4832cbb49c00da34cdb5f