### PR TITLE
Improve LSTM persistence

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 models/*.pkl filter=lfs diff=lfs merge=lfs -text
+models/*.keras filter=lfs diff=lfs merge=lfs -text

--- a/src/predict.py
+++ b/src/predict.py
@@ -7,6 +7,7 @@ from typing import Dict, Any
 
 import joblib
 import pandas as pd
+from tensorflow import keras
 
 from sklearn.metrics import mean_absolute_error, r2_score
 
@@ -25,11 +26,17 @@ MODEL_DIR = Path(__file__).resolve().parents[1] / CONFIG.get("model_dir", "model
 
 def load_models(model_dir: Path) -> Dict[str, Any]:
     models = {}
-    for file in model_dir.glob("*.pkl"):
-        try:
-            models[file.stem] = joblib.load(file)
-        except Exception:
-            logger.error("Failed to load model %s", file)
+    for file in model_dir.iterdir():
+        if file.suffix == ".pkl":
+            try:
+                models[file.stem] = joblib.load(file)
+            except Exception:
+                logger.error("Failed to load model %s", file)
+        elif file.suffix == ".keras":
+            try:
+                models[file.stem] = keras.models.load_model(file)
+            except Exception:
+                logger.error("Failed to load model %s", file)
     if not models:
         raise FileNotFoundError(
             f"No trained models found in {model_dir}. Run the monthly training first."

--- a/src/training.py
+++ b/src/training.py
@@ -248,8 +248,8 @@ def train_models(
                 lstm_grid = {"units": [16, 32], "epochs": [2, 3]}
                 lstm = train_lstm(X_train, y_train, param_grid=lstm_grid, cv=cv_splitter)
                 lstm_path = MODEL_DIR / f"{ticker}_{frequency}_lstm.pkl"
-                joblib.dump(lstm, lstm_path)
-                paths[f"{ticker}_lstm"] = lstm_path
+                lstm.save(lstm_path.with_suffix('.keras'))
+                paths[f"{ticker}_lstm"] = lstm_path.with_suffix('.keras')
                 try:
                     preds_train = lstm.predict(X_train)
                     preds_train = preds_train.flatten() if hasattr(preds_train, "flatten") else preds_train


### PR DESCRIPTION
## Summary
- save LSTM models using Keras format
- load `.keras` models in prediction
- track `.keras` files with LFS

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685f7a939fac832c9d6fd43d4b82499c