### PR TITLE
Fix yfinance logging side effect

### DIFF
--- a/src/preprocess.py
+++ b/src/preprocess.py
@@ -13,11 +13,11 @@ from .utils import (
 )
 
 logger = logging.getLogger(__name__)
-logging.getLogger("yfinance").setLevel(logging.CRITICAL)
 
 
 def extract_data(tickers: List[str], start: str) -> Dict[str, pd.DataFrame]:
     """Download raw price data for a list of tickers."""
+    logging.getLogger("yfinance").setLevel(logging.CRITICAL)
     data = {}
     for t in tickers:
         with timed_stage(f"download {t}"):


### PR DESCRIPTION
## Summary
- prevent module import from altering global logging configuration

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685f7cfae188832cbde281a140fef3ae