### PR TITLE
Improve training CV to mitigate overfitting

### DIFF
--- a/src/training.py
+++ b/src/training.py
@@ -65,7 +65,7 @@ def train_models(
             target_col = "Close"
 
         end_dt = df.index.max()
-        start_cv = end_dt - pd.DateOffset(months=6)
+        start_cv = end_dt - pd.DateOffset(months=12)
         df_recent = df.loc[df.index >= start_cv]
 
         df_recent = df_recent.copy()

--- a/src/utils.py
+++ b/src/utils.py
@@ -64,11 +64,26 @@ def generate_sample_data(start: str, periods: int = 30) -> pd.DataFrame:
 
 def rolling_cv(
     n_samples: int,
-    train_size: int = 60,
-    horizon: int = 1,
-    max_splits: int = 5,
+    train_size: int = 90,
+    horizon: int = 3,
+    max_splits: int = 8,
 ) -> TimeSeriesSplit:
-    """Return a rolling TimeSeriesSplit for short-term forecasting."""
+    """Return a rolling ``TimeSeriesSplit`` for forecasting.
+
+    Parameters
+    ----------
+    n_samples
+        Total number of observations available.
+    train_size
+        Size of each training window. Defaults to ``90`` days for more
+        robust training.
+    horizon
+        Forecast horizon (size of the test window). Defaults to ``3`` days
+        to better capture short-term trends.
+    max_splits
+        Maximum number of CV splits. Increasing this value provides
+        better validation while keeping runtime reasonable.
+    """
     n_splits = min(max_splits, max(1, n_samples - train_size))
     return TimeSeriesSplit(
         n_splits=n_splits,


### PR DESCRIPTION
## Summary
- expand rolling CV defaults with larger window and horizon
- train models using the past 12 months instead of only 6

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685f8b152b74832cbf7834b8870d1c98