### PR TITLE
Add quarterly aggregation workflow

### DIFF
--- a/.github/workflows/quarterly.yml
+++ b/.github/workflows/quarterly.yml
@@ -1,0 +1,34 @@
+name: Quarterly ABT
+permissions:
+  contents: write
+on:
+  schedule:
+    - cron: '0 3 1 */3 *'
+  workflow_dispatch: {}
+jobs:
+  build_quarterly:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          persist-credentials: true
+      - uses: actions/setup-python@v5
+        with:
+          python-version: 3.11
+      - uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements*.txt') }}
+      - name: Instalar dependencias
+        run: |
+          pip install --upgrade pip
+          pip install yfinance==0.2.61 ta==0.11.0 requests-cache==1.2.0 pandas>=2.2
+          pip install -r requirements.txt
+      - run: python -m src.abt.build_abt --quarterly
+      - name: Upload quarterly ABT
+        uses: actions/upload-artifact@v4
+        with:
+          name: quarterly-abt
+          path: data/*_quarterly.csv
+      - run: python -m src.notify.notifier --message "Proceso trimestral completado"

--- a/README.md
+++ b/README.md
@@ -169,6 +169,7 @@ El repositorio incluye flujos de trabajo en `.github/workflows` que ejecutan el 
 
 * `monthly.yml` ejecuta el entrenamiento completo cada tres meses y guarda los modelos resultantes en la carpeta `models/`. Tras entrenar se realiza un commit automatico con cualquier archivo `*.pkl` nuevo o actualizado para mantener la version mas reciente en el repositorio.
 * `weekly.yml` genera la version agregada semanalmente del ABT. Se ejecuta cada lunes y sube los archivos como artefactos.
+* `quarterly.yml` genera la version agregada trimestral del ABT. Se ejecuta cada trimestre y sube los archivos como artefactos.
 * `daily.yml` procesa los datos nuevos y aplica **unicamente** los modelos almacenados en `models/`; no ejecuta ninguna fase de entrenamiento. Las predicciones se escriben en `results/predictions.csv` y se suben mediante un commit automatico cuando existen cambios.
 
 Para que estos flujos puedan subir cambios al repositorio asegúrate de que el `GITHUB_TOKEN` tenga permisos de escritura. Los archivos YAML incluyen `permissions: contents: write`, con lo que el token integrado bastará en la mayoría de los repositorios. Si usas un fork o tu `GITHUB_TOKEN` es de solo lectura, crea un *Personal Access Token* y guárdalo como `GH_PAT`. Luego modifica los workflows para utilizar dicho token al hacer `git push`.


### PR DESCRIPTION
## Summary
- add quarterly resampling for ABT builder
- expose `--quarterly` CLI switch
- document quarterly workflow in README
- schedule quarterly job in new workflow file

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686072317354832ca9f63d333f1b245f