### PR TITLE
Add variable selection utilities

### DIFF
--- a/src/variable_selection.py
+++ b/src/variable_selection.py
@@ -1,0 +1,42 @@
+"""Feature selection utilities."""
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+
+
+def remove_multicollinearity(df: pd.DataFrame, threshold: float = 0.9) -> pd.DataFrame:
+    """Return DataFrame with highly correlated columns removed.
+
+    Parameters
+    ----------
+    df : pd.DataFrame
+        Input feature matrix.
+    threshold : float, optional
+        Absolute correlation above which one of a pair of columns is dropped.
+        Defaults to ``0.9``.
+    """
+    corr = df.corr().abs()
+    upper = corr.where(np.triu(np.ones(corr.shape), k=1).astype(bool))
+    to_drop = [col for col in upper.columns if any(upper[col] > threshold)]
+    return df.drop(columns=to_drop)
+
+
+def select_features(
+    df: pd.DataFrame,
+    target_col: str,
+    corr_threshold: float = 0.9,
+    relevance_threshold: float = 0.05,
+) -> list[str]:
+    """Select relevant features while removing multicollinearity.
+
+    The function first removes features that are highly correlated
+    with each other and then keeps only those features that have
+    at least ``relevance_threshold`` absolute correlation with the target.
+    """
+    df = df.dropna(subset=[target_col])
+    features = df.drop(columns=[target_col])
+    features = remove_multicollinearity(features, threshold=corr_threshold)
+    target_corr = df[features.columns].corrwith(df[target_col]).abs()
+    selected = list(target_corr[target_corr >= relevance_threshold].index)
+    return selected

--- a/src/variable_selection.py
+++ b/src/variable_selection.py
@@ -4,9 +4,13 @@ from __future__ import annotations
 import numpy as np
 import pandas as pd
 
+from sklearn.ensemble import RandomForestRegressor
+from sklearn.inspection import permutation_importance
+from sklearn.model_selection import TimeSeriesSplit
+
 
 def remove_multicollinearity(df: pd.DataFrame, threshold: float = 0.9) -> pd.DataFrame:
-    """Return DataFrame with highly correlated columns removed.
+    """Return ``df`` with highly correlated columns removed.
 
     Parameters
     ----------
@@ -25,18 +29,81 @@ def remove_multicollinearity(df: pd.DataFrame, threshold: float = 0.9) -> pd.Dat
 def select_features(
     df: pd.DataFrame,
     target_col: str,
+    *,
+    sample_size: int | None = 256,
+    n_splits: int = 3,
     corr_threshold: float = 0.9,
-    relevance_threshold: float = 0.05,
 ) -> list[str]:
-    """Select relevant features while removing multicollinearity.
+    """Select features using CV permutation importance and multicollinearity.
 
-    The function first removes features that are highly correlated
-    with each other and then keeps only those features that have
-    at least ``relevance_threshold`` absolute correlation with the target.
+    Parameters
+    ----------
+    df : pd.DataFrame
+        Input dataset with features and target.
+    target_col : str
+        Name of the target column.
+    sample_size : int or None, optional
+        Number of most recent rows to use for the selection. ``None`` uses all
+        rows. Defaults to ``256`` for faster execution on large datasets.
+    n_splits : int, optional
+        Number of CV splits for ``TimeSeriesSplit``. Defaults to ``3``.
+    corr_threshold : float, optional
+        Absolute correlation above which a candidate feature is dropped when
+        another selected feature is already present. Defaults to ``0.9``.
+
+    Returns
+    -------
+    list[str]
+        Ordered list of selected feature names.
+
+    Notes
+    -----
+    The number of returned features is capped at ``sqrt(n_vars) + 7`` where
+    ``n_vars`` is the original feature count. Permutation importance is
+    computed using a ``RandomForestRegressor`` on a rolling ``TimeSeriesSplit``.
+    Multicollinearity is used as a secondary criterion when selecting the most
+    important features.
     """
+
     df = df.dropna(subset=[target_col])
+    if df.empty:
+        return []
+
+    if sample_size is not None and len(df) > sample_size:
+        df = df.tail(sample_size)
+
     features = df.drop(columns=[target_col])
-    features = remove_multicollinearity(features, threshold=corr_threshold)
-    target_corr = df[features.columns].corrwith(df[target_col]).abs()
-    selected = list(target_corr[target_corr >= relevance_threshold].index)
+    y = df[target_col]
+
+    n_splits = min(n_splits, max(1, len(df) - 1))
+    cv = TimeSeriesSplit(n_splits=n_splits)
+    importances = np.zeros(features.shape[1])
+
+    for train_idx, test_idx in cv.split(features):
+        model = RandomForestRegressor(n_estimators=100, random_state=42)
+        model.fit(features.iloc[train_idx], y.iloc[train_idx])
+        result = permutation_importance(
+            model,
+            features.iloc[test_idx],
+            y.iloc[test_idx],
+            n_repeats=5,
+            random_state=42,
+            n_jobs=-1,
+        )
+        importances += result.importances_mean
+    importances /= cv.get_n_splits()
+
+    rankings = pd.Series(importances, index=features.columns).sort_values(
+        ascending=False
+    )
+
+    max_features = int(np.sqrt(len(rankings))) + 7
+    corr = features.corr().abs()
+    selected: list[str] = []
+    for feat in rankings.index:
+        if len(selected) >= max_features:
+            break
+        if all(corr.at[feat, s] <= corr_threshold for s in selected):
+            selected.append(feat)
+
     return selected

--- a/tests/test_variable_selection.py
+++ b/tests/test_variable_selection.py
@@ -34,3 +34,15 @@ def test_select_features_importance_and_multicollinearity():
     assert "x3" in selected
     max_features = int(np.sqrt(df.shape[1] - 1)) + 7
     assert len(selected) <= max_features
+
+def test_remove_multicollinearity_drops_correlated():
+    rng = np.random.default_rng(1)
+    x1 = rng.random(100)
+    x2 = x1 + rng.normal(scale=0.001, size=100)
+    x3 = rng.random(100)
+    df = pd.DataFrame({'x1': x1, 'x2': x2, 'x3': x3})
+    result = vs.remove_multicollinearity(df, threshold=0.8)
+    cols = set(result.columns)
+    assert {'x1', 'x2'} & cols
+    assert not ({'x1', 'x2'} <= cols)
+    assert 'x3' in cols

--- a/tests/test_variable_selection.py
+++ b/tests/test_variable_selection.py
@@ -1,0 +1,28 @@
+import importlib.util
+import pathlib
+import pytest
+
+pd = pytest.importorskip("pandas")
+np = pytest.importorskip("numpy")
+
+if not hasattr(pd.DataFrame, 'corr'):
+    pytest.skip("pandas not installed", allow_module_level=True)
+
+VS_PATH = pathlib.Path(__file__).resolve().parents[1] / 'src' / 'variable_selection.py'
+spec = importlib.util.spec_from_file_location('variable_selection', VS_PATH)
+vs = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(vs)
+select_features = vs.select_features
+
+
+def test_select_features_multicollinearity():
+    n = 100
+    x1 = np.linspace(0, 1, n)
+    x2 = [v * 0.95 + 0.05 for v in x1]
+    x3 = np.linspace(1, 0, n)
+    y = [0.5 * x1[i] + 0.2 * x3[i] for i in range(n)]
+    df = pd.DataFrame({'x1': x1, 'x2': x2, 'x3': x3, 'target': y})
+    selected = select_features(df, 'target', corr_threshold=0.8, relevance_threshold=0.1)
+    assert 'x2' not in selected
+    assert 'x1' in selected
+    assert 'x3' in selected


### PR DESCRIPTION
## Summary
- implement `remove_multicollinearity` and `select_features` helpers
- add tests to cover variable selection logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68607707dc14832c88bf7ef02c8f8869