### PR TITLE
Implement RF-based feature selection

### DIFF
--- a/src/training.py
+++ b/src/training.py
@@ -14,6 +14,7 @@ from .models.linear_model import train_linear
 from .models.lightgbm_model import train_lgbm
 from .models.arima_model import train_arima
 from .utils import timed_stage, log_df_details, log_offline_mode, rolling_cv
+from .variable_selection import select_features_rf_cv
 from .evaluation import evaluate_predictions
 
 # Maximum days required by moving averages or lag features
@@ -101,10 +102,13 @@ def train_models(
             logger.warning("%s has no test data; skipping training", ticker)
             continue
 
-        X_train = df_train.drop(columns=[target_col, "target"], errors="ignore")
+        fs_df = df_train.drop(columns=[target_col], errors="ignore")
+        selected_cols = select_features_rf_cv(fs_df, target_col="target")
+        X_train = df_train[selected_cols]
         y_train = df_train["target"]
-        X_test = df_test.drop(columns=[target_col, "target"], errors="ignore")
+        X_test = df_test[selected_cols]
         y_test = df_test["target"]
+        logger.info("%s selected features: %s", ticker, selected_cols)
         log_df_details(f"train features {ticker}", X_train)
         log_df_details(f"test features {ticker}", X_test)
 

--- a/src/variable_selection.py
+++ b/src/variable_selection.py
@@ -40,3 +40,63 @@ def select_features(
     target_corr = df[features.columns].corrwith(df[target_col]).abs()
     selected = list(target_corr[target_corr >= relevance_threshold].index)
     return selected
+
+
+def select_features_rf_cv(
+    df: pd.DataFrame,
+    target_col: str,
+    max_features: int | None = None,
+    cv: int = 3,
+    corr_threshold: float = 0.9,
+    random_state: int = 42,
+) -> list[str]:
+    """Select features using RandomForest feature importance with CV.
+
+    The top ``max_features`` according to the averaged feature importance are
+    kept and then filtered for multicollinearity.
+
+    Parameters
+    ----------
+    df : pd.DataFrame
+        DataFrame containing features and the target.
+    target_col : str
+        Name of the target column in ``df``.
+    max_features : int, optional
+        Maximum number of features to keep before removing multicollinearity.
+        Defaults to ``sqrt(n_features) + 7``.
+    cv : int, optional
+        Number of time series splits. Defaults to ``3``.
+    corr_threshold : float, optional
+        Threshold to remove correlated features after ranking. Defaults to
+        ``0.9``.
+    random_state : int, optional
+        Random state for ``RandomForestRegressor``. Defaults to ``42``.
+    """
+
+    from sklearn.ensemble import RandomForestRegressor
+    from sklearn.model_selection import TimeSeriesSplit
+
+    df = df.dropna(subset=[target_col])
+    features = df.drop(columns=[target_col])
+    y = df[target_col]
+
+    if features.empty:
+        return []
+
+    n_total = features.shape[1]
+    if max_features is None:
+        max_features = int(np.sqrt(n_total)) + 7
+
+    splits = min(cv, max(1, len(df) - 1))
+    tscv = TimeSeriesSplit(n_splits=splits)
+    importances = np.zeros(n_total)
+    for train_idx, _ in tscv.split(features):
+        model = RandomForestRegressor(random_state=random_state)
+        model.fit(features.iloc[train_idx], y.iloc[train_idx])
+        importances += model.feature_importances_
+    importances /= tscv.get_n_splits()
+
+    order = np.argsort(importances)[::-1]
+    top_cols = features.columns[order[:max_features]]
+    filtered = remove_multicollinearity(features[top_cols], threshold=corr_threshold)
+    return list(filtered.columns)

--- a/tests/test_variable_selection.py
+++ b/tests/test_variable_selection.py
@@ -13,6 +13,7 @@ spec = importlib.util.spec_from_file_location('variable_selection', VS_PATH)
 vs = importlib.util.module_from_spec(spec)
 spec.loader.exec_module(vs)
 select_features = vs.select_features
+select_features_rf_cv = getattr(vs, 'select_features_rf_cv')
 
 
 def test_select_features_multicollinearity():
@@ -26,3 +27,17 @@ def test_select_features_multicollinearity():
     assert 'x2' not in selected
     assert 'x1' in selected
     assert 'x3' in selected
+
+
+def test_select_features_rf_cv_basic():
+    n = 60
+    rng = np.random.default_rng(0)
+    x1 = np.linspace(0, 1, n)
+    x2 = x1 * 0.95 + 0.05
+    x3 = rng.normal(size=n)
+    y = 0.8 * x1 + 0.2 * x3
+    df = pd.DataFrame({'x1': x1, 'x2': x2, 'x3': x3, 'target': y})
+    selected = select_features_rf_cv(df, 'target', cv=2, corr_threshold=0.8)
+    assert sum(f in selected for f in ['x1', 'x2']) == 1
+    assert 'x3' in selected
+    assert len(selected) <= int(np.sqrt(3)) + 7


### PR DESCRIPTION
## Summary
- add `select_features_rf_cv` to select features using RandomForest feature importances with CV
- integrate new selector in `training.py` to pick top variables for all models
- test the selector logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6864a99135fc832c972a32825f19473b