### PR TITLE
Reduce hyperparameter grids

### DIFF
--- a/src/training.py
+++ b/src/training.py
@@ -151,9 +151,9 @@ def train_models(
         with timed_stage(f"train RF {ticker}"):
             try:
                 rf_grid = {
-                    "n_estimators": [20, 30],
-                    "max_depth": [3, None],
-                    "min_samples_leaf": [1, 5],
+                    "n_estimators": [20],
+                    "max_depth": [3],
+                    "min_samples_leaf": [1],
                 }
                 rf = train_rf(X_train, y_train, param_grid=rf_grid, cv=cv_splitter)
                 rf_path = MODEL_DIR / f"{ticker}_{frequency}_rf.pkl"
@@ -189,9 +189,9 @@ def train_models(
         with timed_stage(f"train XGB {ticker}"):
             try:
                 xgb_grid = {
-                    "n_estimators": [50, 75],
-                    "max_depth": [3, 4],
-                    "learning_rate": [0.05, 0.1],
+                    "n_estimators": [50],
+                    "max_depth": [3],
+                    "learning_rate": [0.1],
                 }
                 xgb = train_xgb(X_train, y_train, param_grid=xgb_grid, cv=cv_splitter)
                 xgb_path = MODEL_DIR / f"{ticker}_{frequency}_xgb.pkl"
@@ -227,9 +227,9 @@ def train_models(
         with timed_stage(f"train LGBM {ticker}"):
             try:
                 lgbm_grid = {
-                    "n_estimators": [50, 75],
-                    "max_depth": [3, 4],
-                    "learning_rate": [0.05, 0.1],
+                    "n_estimators": [50],
+                    "max_depth": [3],
+                    "learning_rate": [0.1],
                 }
                 lgbm = train_lgbm(X_train, y_train, param_grid=lgbm_grid, cv=cv_splitter)
                 lgbm_path = MODEL_DIR / f"{ticker}_{frequency}_lgbm.pkl"
@@ -265,10 +265,10 @@ def train_models(
         with timed_stage(f"train LSTM {ticker}"):
             try:
                 lstm_grid = {
-                    "units": [16, 32],
-                    "epochs": [2, 3],
-                    "dropout": [0.0, 0.2],
-                    "l2_reg": [0.0, 0.001],
+                    "units": [16],
+                    "epochs": [2],
+                    "dropout": [0.0],
+                    "l2_reg": [0.0],
                 }
                 lstm = train_lstm(X_train, y_train, param_grid=lstm_grid, cv=cv_splitter)
                 lstm_path = MODEL_DIR / f"{ticker}_{frequency}_lstm.pkl"


### PR DESCRIPTION
## Summary
- narrow search grids used in the training pipeline

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6864af49cd40832c814bed58503ca5af