### PR TITLE
Improve logging with full exception traces

### DIFF
--- a/src/abt/build_abt.py
+++ b/src/abt/build_abt.py
@@ -87,7 +87,7 @@ def download_ticker(
                 if not df.empty:
                     break
             except Exception as exc:
-                logger.error("yf intento %d falló: %s", attempt, exc)
+                logger.exception("yf intento %d falló: %s", attempt, exc)
                 df = pd.DataFrame()
             time.sleep(1)
 
@@ -96,7 +96,7 @@ def download_ticker(
                 df = _download_stooq(ticker, start_dt, today)
                 logger.info("Stooq suministró %d filas para %s", len(df), ticker)
             except Exception as exc:
-                logger.error("Stooq también falló: %s", exc)
+                logger.exception("Stooq también falló: %s", exc)
 
         if df.empty:
             logger.warning("Todo falló. Generando datos de ejemplo.")
@@ -193,7 +193,7 @@ def build_abt(frequency: str = "daily") -> dict:
                 df["Ticker"] = ticker
                 combined_frames.append(df)
         except Exception:
-            logger.error("Failed to download %s", ticker)
+            logger.exception("Failed to download %s", ticker)
 
     if not combined_frames:
         log_offline_mode(f"build_{frequency}_abt")

--- a/src/clean_models.py
+++ b/src/clean_models.py
@@ -23,7 +23,7 @@ def delete_models(model_dir: Path = MODEL_DIR) -> None:
                 item.unlink()
             logger.info("Deleted %s", item)
         except Exception:
-            logger.error("Failed to delete %s", item)
+            logger.exception("Failed to delete %s", item)
 
 
 if __name__ == "__main__":

--- a/src/predict.py
+++ b/src/predict.py
@@ -75,7 +75,7 @@ def load_models(model_dir: Path) -> Dict[str, Any]:
                 else:
                     logger.error("%s does not appear to be a trained model", file)
             except Exception:
-                logger.error("Failed to load model %s", file)
+                logger.exception("Failed to load model %s", file)
         elif file.suffix == ".keras":
             if keras is None:
                 logger.error("TensorFlow unavailable; cannot load %s", file)
@@ -87,7 +87,7 @@ def load_models(model_dir: Path) -> Dict[str, Any]:
                 else:
                     logger.error("%s does not appear to be a trained model", file)
             except Exception:
-                logger.error("Failed to load model %s", file)
+                logger.exception("Failed to load model %s", file)
     if not models:
         logger.warning("No trained models found in %s, using naive defaults", model_dir)
         for ticker in CONFIG.get("etfs", []):
@@ -146,7 +146,7 @@ def run_predictions(
                 "Predict moment": str(predict_dt),
             })
         except Exception:
-            logger.error("Prediction failed for %s", name)
+            logger.exception("Prediction failed for %s", name)
     result_df = pd.DataFrame(rows)
     pred_dir = RESULTS_DIR / "predicts"
     pred_dir.mkdir(exist_ok=True, parents=True)
@@ -160,7 +160,7 @@ def run_predictions(
         result_df.to_csv(out_file, index=False)
         logger.info("Saved predictions to %s", out_file)
     except Exception:
-        logger.error("Failed to save predictions to %s", out_file)
+        logger.exception("Failed to save predictions to %s", out_file)
     log_offline_mode("prediction")
     return result_df
 

--- a/src/preprocess.py
+++ b/src/preprocess.py
@@ -24,7 +24,7 @@ def extract_data(tickers: List[str], start: str) -> Dict[str, pd.DataFrame]:
             try:
                 df = yf.download(t, start=start, progress=False)
             except Exception:
-                logger.error("Failed to download %s, using sample", t)
+                logger.exception("Failed to download %s, using sample", t)
                 df = generate_sample_data(start)
         if df.empty:
             logger.warning("%s download empty, using sample", t)

--- a/src/training.py
+++ b/src/training.py
@@ -144,9 +144,9 @@ def train_models(
                         test_metrics,
                     )
                 except Exception:
-                    logger.error("Failed Linear evaluation for %s", ticker)
+                    logger.exception("Failed Linear evaluation for %s", ticker)
             except Exception:
-                logger.error("Failed Linear training for %s", ticker)
+                logger.exception("Failed Linear training for %s", ticker)
 
         with timed_stage(f"train RF {ticker}"):
             try:
@@ -182,9 +182,9 @@ def train_models(
                         test_metrics,
                     )
                 except Exception:
-                    logger.error("Failed RF evaluation for %s", ticker)
+                    logger.exception("Failed RF evaluation for %s", ticker)
             except Exception:
-                logger.error("Failed RF training for %s", ticker)
+                logger.exception("Failed RF training for %s", ticker)
 
         with timed_stage(f"train XGB {ticker}"):
             try:
@@ -220,9 +220,9 @@ def train_models(
                         test_metrics,
                     )
                 except Exception:
-                    logger.error("Failed XGB evaluation for %s", ticker)
+                    logger.exception("Failed XGB evaluation for %s", ticker)
             except Exception:
-                logger.error("Failed XGB training for %s", ticker)
+                logger.exception("Failed XGB training for %s", ticker)
 
         with timed_stage(f"train LGBM {ticker}"):
             try:
@@ -258,9 +258,9 @@ def train_models(
                         test_metrics,
                     )
                 except Exception:
-                    logger.error("Failed LGBM evaluation for %s", ticker)
+                    logger.exception("Failed LGBM evaluation for %s", ticker)
             except Exception:
-                logger.error("Failed LGBM training for %s", ticker)
+                logger.exception("Failed LGBM training for %s", ticker)
 
         with timed_stage(f"train LSTM {ticker}"):
             try:
@@ -299,9 +299,9 @@ def train_models(
                         test_metrics,
                     )
                 except Exception:
-                    logger.error("Failed LSTM evaluation for %s", ticker)
+                    logger.exception("Failed LSTM evaluation for %s", ticker)
             except Exception:
-                logger.error("Failed LSTM training for %s", ticker)
+                logger.exception("Failed LSTM training for %s", ticker)
 
         with timed_stage(f"train ARIMA {ticker}"):
             try:
@@ -332,9 +332,9 @@ def train_models(
                         test_metrics,
                     )
                 except Exception:
-                    logger.error("Failed ARIMA evaluation for %s", ticker)
+                    logger.exception("Failed ARIMA evaluation for %s", ticker)
             except Exception:
-                logger.error("Failed ARIMA training for %s", ticker)
+                logger.exception("Failed ARIMA training for %s", ticker)
 
     if metrics_rows:
         metrics_df = pd.DataFrame(metrics_rows)
@@ -343,7 +343,7 @@ def train_models(
             metrics_df.to_csv(metrics_file, index=False)
             logger.info("Saved evaluation metrics to %s", metrics_file)
         except Exception:
-            logger.error("Failed to save metrics to %s", metrics_file)
+            logger.exception("Failed to save metrics to %s", metrics_file)
         logger.info("Metrics summary:\n%s", metrics_df)
 
     log_offline_mode("training")


### PR DESCRIPTION
## Summary
- log exceptions when downloading data
- capture stack traces in training failures
- include traceback for prediction failures
- show errors when cleaning models
- log download issues during ABT build

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6864bb2471bc832c87ff4e97a004a68f