### PR TITLE
Enhance hyperparameter tuning

### DIFF
--- a/src/models/lightgbm_model.py
+++ b/src/models/lightgbm_model.py
@@ -4,7 +4,11 @@ import time
 from typing import Any, Dict, Sequence, Union
 
 from lightgbm import LGBMRegressor
-from sklearn.model_selection import GridSearchCV, TimeSeriesSplit, BaseCrossValidator
+from sklearn.model_selection import (
+    RandomizedSearchCV,
+    TimeSeriesSplit,
+    BaseCrossValidator,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -13,29 +17,46 @@ def train_lgbm(
     X_train,
     y_train,
     param_grid: Dict[str, Sequence] | None = None,
-    cv: Union[int, BaseCrossValidator] = 3,
+    cv: Union[int, BaseCrossValidator] = 5,
+    n_iter: int = 10,
     **kwargs,
 ) -> Any:
-    """Train a LightGBM model with optional cross-validation."""
+    """Train a LightGBM model with optional cross-validation.
+
+    Parameters
+    ----------
+    X_train, y_train
+        Training features and target.
+    param_grid
+        Dictionary of parameter distributions for :class:`RandomizedSearchCV`.
+        If ``None``, a small search space is used.
+    cv
+        Number of splits for :class:`TimeSeriesSplit`.
+    n_iter
+        Number of parameter settings that are sampled.
+    kwargs
+        Extra parameters passed directly to ``LGBMRegressor``.
+    """
     start = time.perf_counter()
     logger.info("Training LightGBM model")
 
     if param_grid is None:
         param_grid = {
-            "n_estimators": [50],
-            "max_depth": [3],
-            "learning_rate": [0.1],
+            "n_estimators": [50, 100, 150],
+            "max_depth": [3, 5, 7],
+            "learning_rate": [0.05, 0.1, 0.2],
         }
 
     try:
         base_model = LGBMRegressor(random_state=42, verbosity=-1, **kwargs)
         splitter = TimeSeriesSplit(n_splits=cv) if isinstance(cv, int) else cv
-        search = GridSearchCV(
+        search = RandomizedSearchCV(
             base_model,
-            param_grid=param_grid,
+            param_distributions=param_grid,
             cv=splitter,
             scoring="neg_mean_absolute_error",
             n_jobs=-1,
+            n_iter=n_iter,
         )
         search.fit(X_train, y_train)
         model = search.best_estimator_

--- a/src/models/linear_model.py
+++ b/src/models/linear_model.py
@@ -12,7 +12,7 @@ logger = logging.getLogger(__name__)
 def train_linear(
     X_train,
     y_train,
-    cv: Union[int, BaseCrossValidator] = 3,
+    cv: Union[int, BaseCrossValidator] = 5,
     **kwargs,
 ) -> Any:
     """Train a ridge regression model with basic cross-validation."""

--- a/src/models/lstm_model.py
+++ b/src/models/lstm_model.py
@@ -15,7 +15,7 @@ def train_lstm(
     X_train,
     y_train,
     param_grid: Dict[str, Sequence] | None = None,
-    cv: Union[int, BaseCrossValidator] = 3,
+    cv: Union[int, BaseCrossValidator] = 5,
     **kwargs,
 ) -> Any:
     """Train a simple LSTM using manual cross-validation."""
@@ -24,7 +24,12 @@ def train_lstm(
     logger.info("Training LSTM model")
 
     if param_grid is None:
-        param_grid = {"units": [16], "epochs": [2], "dropout": [0.0], "l2_reg": [0.0]}
+        param_grid = {
+            "units": [16, 32],
+            "epochs": [2, 3],
+            "dropout": [0.0, 0.2],
+            "l2_reg": [0.0, 0.001],
+        }
 
     X = np.asarray(X_train).astype(float)
     y = np.asarray(y_train).astype(float)

--- a/src/models/rf_model.py
+++ b/src/models/rf_model.py
@@ -4,7 +4,11 @@ import time
 from typing import Any, Dict, Sequence, Union
 
 from sklearn.ensemble import RandomForestRegressor
-from sklearn.model_selection import GridSearchCV, TimeSeriesSplit, BaseCrossValidator
+from sklearn.model_selection import (
+    RandomizedSearchCV,
+    TimeSeriesSplit,
+    BaseCrossValidator,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -13,7 +17,8 @@ def train_rf(
     X_train,
     y_train,
     param_grid: Dict[str, Sequence] | None = None,
-    cv: Union[int, BaseCrossValidator] = 3,
+    cv: Union[int, BaseCrossValidator] = 5,
+    n_iter: int = 10,
     **kwargs,
 ) -> Any:
     """Train a Random Forest with optional cross-validation.
@@ -23,10 +28,12 @@ def train_rf(
     X_train, y_train
         Training features and target.
     param_grid
-        Dictionary of parameters for :class:`GridSearchCV`. If ``None``, a
-        minimal grid with ``n_estimators`` and ``max_depth`` is used.
+        Dictionary of parameter distributions for :class:`RandomizedSearchCV`.
+        If ``None``, a small search space is used.
     cv
         Number of splits for :class:`TimeSeriesSplit`.
+    n_iter
+        Number of parameter settings that are sampled.
     kwargs
         Extra parameters passed directly to ``RandomForestRegressor``.
     """
@@ -36,20 +43,21 @@ def train_rf(
 
     if param_grid is None:
         param_grid = {
-            "n_estimators": [20],
-            "max_depth": [3],
-            "min_samples_leaf": [1],
+            "n_estimators": [50, 100, 150],
+            "max_depth": [3, 5, 7],
+            "min_samples_leaf": [1, 2],
         }
 
     try:
         base_model = RandomForestRegressor(random_state=42, **kwargs)
         splitter = TimeSeriesSplit(n_splits=cv) if isinstance(cv, int) else cv
-        search = GridSearchCV(
+        search = RandomizedSearchCV(
             base_model,
-            param_grid=param_grid,
+            param_distributions=param_grid,
             cv=splitter,
             scoring="neg_mean_absolute_error",
             n_jobs=-1,
+            n_iter=n_iter,
         )
         search.fit(X_train, y_train)
         model = search.best_estimator_

--- a/src/models/xgb_model.py
+++ b/src/models/xgb_model.py
@@ -4,7 +4,11 @@ import time
 from typing import Any, Dict, Sequence, Union
 
 from xgboost import XGBRegressor
-from sklearn.model_selection import GridSearchCV, TimeSeriesSplit, BaseCrossValidator
+from sklearn.model_selection import (
+    RandomizedSearchCV,
+    TimeSeriesSplit,
+    BaseCrossValidator,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -13,30 +17,47 @@ def train_xgb(
     X_train,
     y_train,
     param_grid: Dict[str, Sequence] | None = None,
-    cv: Union[int, BaseCrossValidator] = 3,
+    cv: Union[int, BaseCrossValidator] = 5,
+    n_iter: int = 10,
     **kwargs,
 ) -> Any:
-    """Train an XGBoost model with optional cross-validation."""
+    """Train an XGBoost model with optional cross-validation.
+
+    Parameters
+    ----------
+    X_train, y_train
+        Training features and target.
+    param_grid
+        Dictionary of parameter distributions for :class:`RandomizedSearchCV`.
+        If ``None``, a small search space is used.
+    cv
+        Number of splits for :class:`TimeSeriesSplit`.
+    n_iter
+        Number of parameter settings that are sampled.
+    kwargs
+        Extra parameters passed directly to ``XGBRegressor``.
+    """
 
     start = time.perf_counter()
     logger.info("Training XGBoost model")
 
     if param_grid is None:
         param_grid = {
-            "n_estimators": [50],
-            "max_depth": [3],
-            "learning_rate": [0.1],
+            "n_estimators": [50, 100, 150],
+            "max_depth": [3, 5, 7],
+            "learning_rate": [0.05, 0.1, 0.2],
         }
 
     try:
         base_model = XGBRegressor(random_state=42, verbosity=0, **kwargs)
         splitter = TimeSeriesSplit(n_splits=cv) if isinstance(cv, int) else cv
-        search = GridSearchCV(
+        search = RandomizedSearchCV(
             base_model,
-            param_grid=param_grid,
+            param_distributions=param_grid,
             cv=splitter,
             scoring="neg_mean_absolute_error",
             n_jobs=-1,
+            n_iter=n_iter,
         )
         search.fit(X_train, y_train)
         model = search.best_estimator_

--- a/src/training.py
+++ b/src/training.py
@@ -114,7 +114,7 @@ def train_models(
         log_df_details(f"test features {ticker}", X_test)
 
         n_samples = len(df_train)
-        cv_splitter = rolling_cv(n_samples)
+        cv_splitter = rolling_cv(n_samples, max_splits=12)
 
         with timed_stage(f"train Linear {ticker}"):
             try:
@@ -155,9 +155,9 @@ def train_models(
         with timed_stage(f"train RF {ticker}"):
             try:
                 rf_grid = {
-                    "n_estimators": [20],
-                    "max_depth": [3],
-                    "min_samples_leaf": [1],
+                    "n_estimators": [50, 100, 150],
+                    "max_depth": [3, 5, 7],
+                    "min_samples_leaf": [1, 2],
                 }
                 rf = train_rf(X_train, y_train, param_grid=rf_grid, cv=cv_splitter)
                 rf_path = MODEL_DIR / f"{ticker}_{frequency}_rf.pkl"
@@ -196,9 +196,9 @@ def train_models(
         with timed_stage(f"train XGB {ticker}"):
             try:
                 xgb_grid = {
-                    "n_estimators": [50],
-                    "max_depth": [3],
-                    "learning_rate": [0.1],
+                    "n_estimators": [50, 100, 150],
+                    "max_depth": [3, 5, 7],
+                    "learning_rate": [0.05, 0.1, 0.2],
                 }
                 xgb = train_xgb(X_train, y_train, param_grid=xgb_grid, cv=cv_splitter)
                 xgb_path = MODEL_DIR / f"{ticker}_{frequency}_xgb.pkl"
@@ -237,9 +237,9 @@ def train_models(
         with timed_stage(f"train LGBM {ticker}"):
             try:
                 lgbm_grid = {
-                    "n_estimators": [50],
-                    "max_depth": [3],
-                    "learning_rate": [0.1],
+                    "n_estimators": [50, 100, 150],
+                    "max_depth": [3, 5, 7],
+                    "learning_rate": [0.05, 0.1, 0.2],
                 }
                 lgbm = train_lgbm(X_train, y_train, param_grid=lgbm_grid, cv=cv_splitter)
                 lgbm_path = MODEL_DIR / f"{ticker}_{frequency}_lgbm.pkl"
@@ -278,10 +278,10 @@ def train_models(
         with timed_stage(f"train LSTM {ticker}"):
             try:
                 lstm_grid = {
-                    "units": [16],
-                    "epochs": [2],
-                    "dropout": [0.0],
-                    "l2_reg": [0.0],
+                    "units": [16, 32],
+                    "epochs": [2, 3],
+                    "dropout": [0.0, 0.2],
+                    "l2_reg": [0.0, 0.001],
                 }
                 lstm = train_lstm(X_train, y_train, param_grid=lstm_grid, cv=cv_splitter)
                 lstm_path = MODEL_DIR / f"{ticker}_{frequency}_lstm.pkl"

--- a/src/utils.py
+++ b/src/utils.py
@@ -115,7 +115,7 @@ def rolling_cv(
     n_samples: int,
     train_size: int = 90,
     horizon: int = 3,
-    max_splits: int = 10,
+    max_splits: int = 12,
 ) -> TimeSeriesSplit:
     """Return a rolling ``TimeSeriesSplit`` for forecasting.
 


### PR DESCRIPTION
## Summary
- increase rolling cross validation splits
- add more hyperparameters and use RandomizedSearchCV in RandomForest, XGBoost and LightGBM trainers
- expand LSTM search space
- bump default CV for linear models
- update training pipeline grids

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6864cac8411c832c92f9f258a07cbe6d