### PR TITLE
Add data windows to metrics output

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,9 @@ Ademas existen scripts de seleccion y prediccion en la raiz del paquete para eje
    verás un resumen de las matrices de entrenamiento usadas para cada ticker.
    Tras entrenar se calculan métricas y se guardan en la carpeta indicada por
    `evaluation_dir`. Cada archivo lleva la fecha del entrenamiento y las
-   métricas también se imprimen en los logs.
+   métricas también se imprimen en los logs. El CSV incluye las columnas
+   `ABT Window`, `Test Window` y `Predict Date` para dejar constancia de los
+   rangos utilizados y la fecha que se pronostica.
 
 4. **Prediccion**
 

--- a/src/training.py
+++ b/src/training.py
@@ -84,6 +84,14 @@ def train_models(
         val_start = df_recent.index.max() - pd.Timedelta(days=7)
         df_train = df_recent[df_recent.index < val_start]
         df_test = df_recent[df_recent.index >= val_start]
+
+        abt_start = df_recent.index.min().date()
+        abt_end = df_recent.index.max().date()
+        test_start = df_test.index.min().date()
+        test_end = df_test.index.max().date()
+        abt_window = f"{abt_start} a {abt_end}"
+        test_window = f"{test_start} a {test_end}"
+        predict_date = test_end
         logger.info(
             "%s train %s to %s | validation %s to %s",
             ticker,
@@ -129,7 +137,9 @@ def train_models(
                         "model": f"{ticker}_linreg",
                         "dataset": "train",
                         **train_metrics,
-                        "run_date": RUN_TIMESTAMP,
+                        "ABT Window": abt_window,
+                        "Test Window": test_window,
+                        "Predict Date": predict_date,
                     })
                     preds_test = lin.predict(X_test)
                     test_metrics = evaluate_predictions(y_test, preds_test)
@@ -137,7 +147,9 @@ def train_models(
                         "model": f"{ticker}_linreg",
                         "dataset": "test",
                         **test_metrics,
-                        "run_date": RUN_TIMESTAMP,
+                        "ABT Window": abt_window,
+                        "Test Window": test_window,
+                        "Predict Date": predict_date,
                     })
                     logger.info(
                         "Linear train metrics %s | test metrics %s",
@@ -168,7 +180,9 @@ def train_models(
                         "model": f"{ticker}_rf",
                         "dataset": "train",
                         **train_metrics,
-                        "run_date": RUN_TIMESTAMP,
+                        "ABT Window": abt_window,
+                        "Test Window": test_window,
+                        "Predict Date": predict_date,
                     })
                     preds_test = rf.predict(X_test)
                     test_metrics = evaluate_predictions(y_test, preds_test)
@@ -176,7 +190,9 @@ def train_models(
                         "model": f"{ticker}_rf",
                         "dataset": "test",
                         **test_metrics,
-                        "run_date": RUN_TIMESTAMP,
+                        "ABT Window": abt_window,
+                        "Test Window": test_window,
+                        "Predict Date": predict_date,
                     })
                     logger.info(
                         "RF train metrics %s | test metrics %s",
@@ -207,7 +223,9 @@ def train_models(
                         "model": f"{ticker}_xgb",
                         "dataset": "train",
                         **train_metrics,
-                        "run_date": RUN_TIMESTAMP,
+                        "ABT Window": abt_window,
+                        "Test Window": test_window,
+                        "Predict Date": predict_date,
                     })
                     preds_test = xgb.predict(X_test)
                     test_metrics = evaluate_predictions(y_test, preds_test)
@@ -215,7 +233,9 @@ def train_models(
                         "model": f"{ticker}_xgb",
                         "dataset": "test",
                         **test_metrics,
-                        "run_date": RUN_TIMESTAMP,
+                        "ABT Window": abt_window,
+                        "Test Window": test_window,
+                        "Predict Date": predict_date,
                     })
                     logger.info(
                         "XGB train metrics %s | test metrics %s",
@@ -246,7 +266,9 @@ def train_models(
                         "model": f"{ticker}_lgbm",
                         "dataset": "train",
                         **train_metrics,
-                        "run_date": RUN_TIMESTAMP,
+                        "ABT Window": abt_window,
+                        "Test Window": test_window,
+                        "Predict Date": predict_date,
                     })
                     preds_test = lgbm.predict(X_test)
                     test_metrics = evaluate_predictions(y_test, preds_test)
@@ -254,7 +276,9 @@ def train_models(
                         "model": f"{ticker}_lgbm",
                         "dataset": "test",
                         **test_metrics,
-                        "run_date": RUN_TIMESTAMP,
+                        "ABT Window": abt_window,
+                        "Test Window": test_window,
+                        "Predict Date": predict_date,
                     })
                     logger.info(
                         "LGBM train metrics %s | test metrics %s",
@@ -290,7 +314,9 @@ def train_models(
                         "model": f"{ticker}_lstm",
                         "dataset": "train",
                         **train_metrics,
-                        "run_date": RUN_TIMESTAMP,
+                        "ABT Window": abt_window,
+                        "Test Window": test_window,
+                        "Predict Date": predict_date,
                     })
                     preds_test = lstm.predict(X_test)
                     preds_test = preds_test.flatten() if hasattr(preds_test, "flatten") else preds_test
@@ -299,7 +325,9 @@ def train_models(
                         "model": f"{ticker}_lstm",
                         "dataset": "test",
                         **test_metrics,
-                        "run_date": RUN_TIMESTAMP,
+                        "ABT Window": abt_window,
+                        "Test Window": test_window,
+                        "Predict Date": predict_date,
                     })
                     logger.info(
                         "LSTM train metrics %s | test metrics %s",
@@ -325,7 +353,9 @@ def train_models(
                         "model": f"{ticker}_arima",
                         "dataset": "train",
                         **train_metrics,
-                        "run_date": RUN_TIMESTAMP,
+                        "ABT Window": abt_window,
+                        "Test Window": test_window,
+                        "Predict Date": predict_date,
                     })
                     preds_test = arima.predict(X_test)
                     test_metrics = evaluate_predictions(y_test, preds_test)
@@ -333,7 +363,9 @@ def train_models(
                         "model": f"{ticker}_arima",
                         "dataset": "test",
                         **test_metrics,
-                        "run_date": RUN_TIMESTAMP,
+                        "ABT Window": abt_window,
+                        "Test Window": test_window,
+                        "Predict Date": predict_date,
                     })
                     logger.info(
                         "ARIMA train metrics %s | test metrics %s",


### PR DESCRIPTION
## Summary
- save metrics along with ABT and test windows
- clarify new metric columns in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6868bd545ee4832ca40ae5d7eaf66b1c