### PR TITLE
Improve schema validation error handling

### DIFF
--- a/src/abt/build_abt.py
+++ b/src/abt/build_abt.py
@@ -52,6 +52,7 @@ def _download_yahoo(ticker, start, end, interval):
         interval=interval,
         progress=False,
         threads=False,
+        auto_adjust=False,
     )
 
 

--- a/src/preprocess.py
+++ b/src/preprocess.py
@@ -22,7 +22,9 @@ def extract_data(tickers: List[str], start: str) -> Dict[str, pd.DataFrame]:
     for t in tickers:
         with timed_stage(f"download {t}"):
             try:
-                df = yf.download(t, start=start, progress=False)
+                # yfinance 0.2.37 changed auto_adjust default to True.
+                # Force False to maintain the schema used during training.
+                df = yf.download(t, start=start, progress=False, auto_adjust=False)
             except Exception:
                 logger.exception("Failed to download %s, using sample", t)
                 df = generate_sample_data(start)

--- a/src/selection.py
+++ b/src/selection.py
@@ -11,7 +11,15 @@ logger = logging.getLogger(__name__)
 
 def _fetch_history(ticker: str, start: str, end: str) -> pd.DataFrame:
     """Download OHLCV data for a ticker."""
-    return yf.download(ticker, start=start, end=end, progress=False)
+    # Explicitly disable auto_adjust to keep raw prices consistent across
+    # yfinance versions (the default switched to True in 0.2.37).
+    return yf.download(
+        ticker,
+        start=start,
+        end=end,
+        progress=False,
+        auto_adjust=False,
+    )
 
 
 def select_tickers(candidates: List[str], end_date: str) -> List[str]:

--- a/src/utils/schema_guard.py
+++ b/src/utils/schema_guard.py
@@ -35,6 +35,12 @@ def load_with_schema(path: str | Path) -> Tuple[Any, list[str], str]:
 
 def validate_schema(feature_list: Iterable[str], df: pd.DataFrame, schema_hash: str) -> None:
     """Validate columns against stored schema, exit 99 on mismatch."""
+    missing = [c for c in feature_list if c not in df.columns]
+    if missing:
+        logger.error("\u2716 SCHEMA MISMATCH \u2716")
+        logger.error("Columnas faltantes: %s", ", ".join(missing))
+        raise SystemExit(99)
+
     subset = df[list(feature_list)]
     live_hash = hash_schema(subset)
     if live_hash != schema_hash:

--- a/tests/test_schema_guard.py
+++ b/tests/test_schema_guard.py
@@ -1,0 +1,17 @@
+import pytest
+pd = pytest.importorskip("pandas")
+from src.utils.schema_guard import hash_schema, validate_schema
+
+
+def test_validate_schema_success():
+    df = pd.DataFrame({"feat_0": [1], "feat_1": [2], "feat_2": [3]})
+    schema_hash = hash_schema(df)
+    validate_schema(list(df.columns), df, schema_hash)
+
+
+def test_validate_schema_missing():
+    df = pd.DataFrame({"feat_0": [1], "feat_1": [2]})
+    feature_list = ["feat_0", "feat_1", "feat_2"]
+    schema_hash = hash_schema(pd.DataFrame(columns=feature_list))
+    with pytest.raises(SystemExit):
+        validate_schema(feature_list, df, schema_hash)


### PR DESCRIPTION
## Summary
- handle missing columns in `validate_schema`
- add tests for schema validation
- fix yfinance `auto_adjust` behavior to keep columns stable

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6868c37b97fc832c8ceaf1de301f4e7b