### PR TITLE
Improve model regularization

### DIFF
--- a/src/models/linear_model.py
+++ b/src/models/linear_model.py
@@ -1,7 +1,7 @@
 """Simple ridge regression utilities."""
 import logging
 import time
-from typing import Any, Union
+from typing import Any, Union, Sequence
 
 from sklearn.linear_model import Ridge
 from sklearn.model_selection import TimeSeriesSplit, cross_val_score, BaseCrossValidator
@@ -13,26 +13,44 @@ def train_linear(
     X_train,
     y_train,
     cv: Union[int, BaseCrossValidator] = 5,
+    alphas: Sequence[float] | None = None,
     **kwargs,
 ) -> Any:
-    """Train a ridge regression model with basic cross-validation."""
+    """Train a ridge regression model with basic cross-validation.
+
+    Parameters
+    ----------
+    alphas
+        Optional list of ``alpha`` values to evaluate. The value with the
+        lowest validation error is used for the final model.
+    """
     start = time.perf_counter()
     logger.info("Training Ridge Regression model")
 
     try:
-        # Use an SVD-based solver for numerical stability when the feature
-        # matrix is ill-conditioned. This avoids ``LinAlgWarning`` messages
-        # that can appear with the default solver on highly correlated data.
-        model = Ridge(solver="svd", **kwargs)
+        if alphas is None:
+            alphas = [0.1, 1.0, 10.0]
+
         splitter = TimeSeriesSplit(n_splits=cv) if isinstance(cv, int) else cv
-        scores = cross_val_score(
-            model,
-            X_train,
-            y_train,
-            cv=splitter,
-            scoring="neg_mean_absolute_error",
-        )
-        logger.info("Ridge CV MAE: %.4f", -scores.mean())
+        best_alpha = alphas[0]
+        best_score = float("inf")
+        for alpha in alphas:
+            model = Ridge(alpha=alpha, solver="svd", **kwargs)
+            scores = cross_val_score(
+                model,
+                X_train,
+                y_train,
+                cv=splitter,
+                scoring="neg_mean_absolute_error",
+            )
+            score = -scores.mean()
+            if score < best_score:
+                best_score = score
+                best_alpha = alpha
+
+        logger.info("Ridge best alpha: %s", best_alpha)
+
+        model = Ridge(alpha=best_alpha, solver="svd", **kwargs)
         model.fit(X_train, y_train)
     except Exception:
         logger.exception("Error while training Ridge Regression")

--- a/src/models/lstm_model.py
+++ b/src/models/lstm_model.py
@@ -6,6 +6,7 @@ from typing import Any, Dict, Sequence, Union
 import numpy as np
 from tensorflow import keras
 from tensorflow.keras import layers
+from tensorflow.keras.callbacks import EarlyStopping
 from sklearn.model_selection import TimeSeriesSplit, BaseCrossValidator
 
 logger = logging.getLogger(__name__)
@@ -62,7 +63,14 @@ def train_lstm(
                                 layers.Dense(1, kernel_regularizer=reg),
                             ])
                             model.compile(optimizer="adam", loss="mse")
-                            model.fit(X_tr, y_tr, epochs=epochs, verbose=0)
+                            es = EarlyStopping(patience=2, restore_best_weights=True)
+                            model.fit(
+                                X_tr,
+                                y_tr,
+                                epochs=epochs,
+                                verbose=0,
+                                callbacks=[es],
+                            )
                             val_pred = model.predict(X_val, verbose=0).flatten()
                             scores.append(np.mean(np.abs(y_val - val_pred)))
 
@@ -95,7 +103,14 @@ def train_lstm(
             layers.Dense(1, kernel_regularizer=final_reg),
         ])
         model.compile(optimizer="adam", loss="mse")
-        model.fit(X, y, epochs=best_params["epochs"], verbose=0)
+        es_final = EarlyStopping(patience=2, restore_best_weights=True)
+        model.fit(
+            X,
+            y,
+            epochs=best_params["epochs"],
+            verbose=0,
+            callbacks=[es_final],
+        )
     except Exception:
         logger.exception("Error while training LSTM")
         raise

--- a/src/training.py
+++ b/src/training.py
@@ -126,11 +126,11 @@ def train_models(
         log_df_details(f"test features {ticker}", X_test)
 
         n_samples = len(df_train)
-        cv_splitter = rolling_cv(n_samples, max_splits=12)
+        cv_splitter = rolling_cv(n_samples, horizon=1, max_splits=24)
 
         with timed_stage(f"train Linear {ticker}"):
             try:
-                lin = train_linear(X_train, y_train, cv=cv_splitter, alpha=2.0)
+                lin = train_linear(X_train, y_train, cv=cv_splitter)
                 schema_hash = hash_schema(X_train)
                 lin_path = MODEL_DIR / f"{ticker}_{frequency}_linreg_{schema_hash}.joblib"
                 save_with_schema(lin, lin_path, selected_cols, schema_hash)

--- a/src/utils/__init__.py
+++ b/src/utils/__init__.py
@@ -114,8 +114,8 @@ def generate_sample_data(start: str, periods: int = 30) -> pd.DataFrame:
 def rolling_cv(
     n_samples: int,
     train_size: int = 90,
-    horizon: int = 3,
-    max_splits: int = 12,
+    horizon: int = 1,
+    max_splits: int = 24,
 ) -> TimeSeriesSplit:
     """Return a rolling ``TimeSeriesSplit`` for forecasting.
 
@@ -127,11 +127,13 @@ def rolling_cv(
         Size of each training window. Defaults to ``90`` days for more
         robust training.
     horizon
-        Forecast horizon (size of the test window). Defaults to ``3`` days
-        to better capture short-term trends.
+        Forecast horizon (size of the test window). Defaults to ``1`` day to
+        ensure next-day predictions in each validation split.
     max_splits
-        Maximum number of CV splits. Increasing this value provides
-        better validation while keeping runtime reasonable.
+        Maximum number of CV splits. Defaults to ``24`` so that more
+        repetitions are used during rolling cross-validation. Increasing
+        this value provides better validation while keeping runtime
+        reasonable.
     """
     n_splits = min(max_splits, max(1, n_samples - train_size))
     return TimeSeriesSplit(


### PR DESCRIPTION
## Summary
- use horizon=1 in `rolling_cv` for next-day prediction splits
- add early stopping to the LSTM training loop
- tune Ridge regression `alpha` using cross-validation
- increase rolling CV repetitions to reduce overfitting

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6868c57a7528832c995fab63cb7f29a2