### PR TITLE
Fix EarlyStopping warning in LSTM model

### DIFF
--- a/src/models/lstm_model.py
+++ b/src/models/lstm_model.py
@@ -63,7 +63,13 @@ def train_lstm(
                                 layers.Dense(1, kernel_regularizer=reg),
                             ])
                             model.compile(optimizer="adam", loss="mse")
-                            es = EarlyStopping(patience=2, restore_best_weights=True)
+                            # Monitor training loss because no validation data
+                            # is provided during cross-validation
+                            es = EarlyStopping(
+                                monitor="loss",
+                                patience=2,
+                                restore_best_weights=True,
+                            )
                             model.fit(
                                 X_tr,
                                 y_tr,
@@ -103,7 +109,13 @@ def train_lstm(
             layers.Dense(1, kernel_regularizer=final_reg),
         ])
         model.compile(optimizer="adam", loss="mse")
-        es_final = EarlyStopping(patience=2, restore_best_weights=True)
+        # When fitting the final model we also monitor training loss
+        # because no validation set is used.
+        es_final = EarlyStopping(
+            monitor="loss",
+            patience=2,
+            restore_best_weights=True,
+        )
         model.fit(
             X,
             y,


### PR DESCRIPTION
## Summary
- monitor `loss` instead of `val_loss` during LSTM training since no validation data is provided

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68693cf60408832caf4c60b946664b8e