### PR TITLE
Improve LSTM training stability

### DIFF
--- a/src/training.py
+++ b/src/training.py
@@ -341,15 +341,15 @@ def train_models(
             try:
                 lstm_grid = {
                     "units": [8, 16],
-                    "batch": [64, 128],
-                    "epochs": [2, 3],
-                    "dropout": [0.2, 0.4],
+                    "batch": [64],
+                    "epochs": [2],
                     "l2_reg": [0.001, 0.01],
                 }
                 lstm = train_lstm(
                     X_train,
                     y_train,
                     param_space=lstm_grid,
+                    n_iter=2,
                     cv_splits=cv_splitter.n_splits,
                 )
                 lstm_path = MODEL_DIR / f"{ticker}_{frequency}_lstm.pkl"


### PR DESCRIPTION
## Summary
- ensure LSTM datasets use a fixed batch shape
- cut down random search iterations and set constant batch size
- add helper to prepare prediction inputs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686951ee1740832c9aa10c4c94a591f1