### PR TITLE
Sort time series before computing features

### DIFF
--- a/src/abt/build_abt.py
+++ b/src/abt/build_abt.py
@@ -107,6 +107,9 @@ def download_ticker(
             df = df.copy()
             df.columns = df.columns.get_level_values(0)
 
+        # ensure rows are in chronological order for rolling features
+        df = df.sort_index()
+
     log_df_details(f"downloaded {ticker}", df)
     return df
 

--- a/src/features.py
+++ b/src/features.py
@@ -162,13 +162,15 @@ def _add_decomposition(df: pd.DataFrame) -> pd.DataFrame:
 def add_technical_indicators(df: pd.DataFrame) -> pd.DataFrame:
     """Apply a set of technical indicators to a DataFrame.
 
-    If a ``Ticker`` column is present the indicators are computed
-    independently for each ticker.
+    The input series must be sorted in ascending date order. This function
+    enforces that ordering before computing indicators. If a ``Ticker`` column
+    is present the indicators are computed independently for each ticker.
     """
     if df.empty:
         return df
 
     def enrich(group: pd.DataFrame) -> pd.DataFrame:
+        group = group.sort_index()
         group = _add_basic_indicators(group)
         group = _add_advanced_indicators(group)
         group = _add_return_features(group)

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -59,3 +59,12 @@ def test_stl_columns_added():
         for comp in ["trend", "seasonal", "resid"]:
             assert f"stl_{comp}_{w}" in result.columns
 
+
+def test_unsorted_input_is_sorted_before_features():
+    idx = pd.date_range(start="2020-01-01", periods=10, freq="D")
+    df = pd.DataFrame({"Close": range(10)}, index=idx)
+    df_desc = df.iloc[::-1]
+    result = add_technical_indicators(df_desc)
+    expected = add_technical_indicators(df)
+    pd.testing.assert_frame_equal(result, expected)
+


### PR DESCRIPTION
## Summary
- ensure data is in chronological order right after download
- sort each group inside `add_technical_indicators`
- clarify requirement in docstring
- test that unsorted data produces same result as sorted

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686985d54638832cb522034ad44f2ae2