### PR TITLE
Add diff sign features

### DIFF
--- a/src/features.py
+++ b/src/features.py
@@ -159,6 +159,17 @@ def _add_decomposition(df: pd.DataFrame) -> pd.DataFrame:
     return df
 
 
+def _add_diff_sign_features(df: pd.DataFrame) -> pd.DataFrame:
+    """Add binary indicators for positive differences in key columns."""
+    df = df.copy()
+    columns = ["Close"] + [f"median_{w}" for w in [5, 10, 20, 50]]
+    for col in columns:
+        if col in df.columns:
+            diff = df[col].diff()
+            df[f"{col}_up"] = (diff > 0).astype(int)
+    return df
+
+
 def add_technical_indicators(df: pd.DataFrame) -> pd.DataFrame:
     """Apply a set of technical indicators to a DataFrame.
 
@@ -176,6 +187,7 @@ def add_technical_indicators(df: pd.DataFrame) -> pd.DataFrame:
         group = _add_return_features(group)
         group = _add_lag_features(group)
         group = _add_window_stats(group)
+        group = _add_diff_sign_features(group)
         group = _add_seasonal_features(group)
         group = _add_trend_line(group)
         group = _add_decomposition(group)

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -68,3 +68,22 @@ def test_unsorted_input_is_sorted_before_features():
     expected = add_technical_indicators(df)
     pd.testing.assert_frame_equal(result, expected)
 
+
+def test_diff_sign_features():
+    idx = pd.date_range(start="2020-01-01", periods=3, freq="D")
+    df = pd.DataFrame({
+        "Open": [1, 2, 1],
+        "High": [1, 2, 1],
+        "Low": [1, 2, 1],
+        "Close": [1, 2, 1],
+        "Adj Close": [1, 2, 1],
+        "Volume": [1, 1, 1],
+    }, index=idx)
+    result = add_technical_indicators(df)
+    assert "Close_up" in result.columns
+    assert "median_5_up" in result.columns
+    expected_close = (df["Close"].diff() > 0).astype(int)
+    pd.testing.assert_series_equal(result["Close_up"], expected_close, check_name=False)
+    expected_median = (result["median_5"].diff() > 0).astype(int)
+    pd.testing.assert_series_equal(result["median_5_up"], expected_median, check_name=False)
+


### PR DESCRIPTION
## Summary
- add `_add_diff_sign_features` to create 1/0 indicators for positive differences
- include these new columns for `Close` and rolling medians in the pipeline
- test for the new features

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68698aab8f84832c839c62ff46ee8933