### PR TITLE
Add diff sign features for medians

### DIFF
--- a/src/features.py
+++ b/src/features.py
@@ -29,6 +29,9 @@ def _add_window_stats(df: pd.DataFrame) -> pd.DataFrame:
         df[f"q75_{w}"] = roll.quantile(0.75)
         df[f"max_{w}"] = roll.max()
         df[f"std_{w}"] = roll.std()
+        # Additional indicators
+        df[f"ema_{w}"] = df["Close"].ewm(span=w, adjust=False, min_periods=1).mean()
+        df[f"norm_band_{w}"] = (df["Close"] - df[f"ma_{w}"]) / df[f"std_{w}"]
     return df
 
 
@@ -59,9 +62,10 @@ def _add_advanced_indicators(df: pd.DataFrame) -> pd.DataFrame:
 
 
 def _add_return_features(df: pd.DataFrame) -> pd.DataFrame:
-    """Add log returns and simple volatility estimates."""
+    """Add returns and simple volatility estimates."""
     df = df.copy()
     df["log_return"] = np.log(df["Close"]).diff()
+    df["simple_return"] = df["Close"].pct_change()
     df["volatility_5"] = df["log_return"].rolling(window=5, min_periods=1).std()
     df["volatility_10"] = df["log_return"].rolling(window=10, min_periods=1).std()
     return df
@@ -160,12 +164,14 @@ def _add_decomposition(df: pd.DataFrame) -> pd.DataFrame:
 
 
 def _add_diff_sign_features(df: pd.DataFrame) -> pd.DataFrame:
-    """Add binary indicators for positive differences in key columns."""
+    """Add binary indicators for positive day-over-day changes."""
     df = df.copy()
+
     columns = ["Close"] + [f"median_{w}" for w in [5, 10, 20, 50]]
     for col in columns:
         if col in df.columns:
-            diff = df[col].diff()
+            # Use previous value only to avoid look-ahead bias
+            diff = df[col] - df[col].shift(1)
             df[f"{col}_up"] = (diff > 0).astype(int)
     return df
 

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -81,9 +81,32 @@ def test_diff_sign_features():
     }, index=idx)
     result = add_technical_indicators(df)
     assert "Close_up" in result.columns
-    assert "median_5_up" in result.columns
     expected_close = (df["Close"].diff() > 0).astype(int)
     pd.testing.assert_series_equal(result["Close_up"], expected_close, check_name=False)
-    expected_median = (result["median_5"].diff() > 0).astype(int)
-    pd.testing.assert_series_equal(result["median_5_up"], expected_median, check_name=False)
+
+    for w in [5, 10, 20, 50]:
+        col = f"median_{w}_up"
+        assert col in result.columns
+        expected = (result[f"median_{w}"].diff() > 0).astype(int)
+        pd.testing.assert_series_equal(result[col], expected, check_name=False)
+
+
+def test_ema_and_norm_band_and_simple_return():
+    idx = pd.date_range(start="2020-01-01", periods=60, freq="D")
+    df = pd.DataFrame({
+        "Open": range(60),
+        "High": range(60),
+        "Low": range(60),
+        "Close": range(60),
+        "Adj Close": range(60),
+        "Volume": range(60),
+    }, index=idx)
+    result = add_technical_indicators(df)
+    for w in [5, 10, 20, 50]:
+        assert f"ema_{w}" in result.columns
+        assert f"norm_band_{w}" in result.columns
+
+    assert "simple_return" in result.columns
+    expected_simple = df["Close"].pct_change()
+    pd.testing.assert_series_equal(result["simple_return"], expected_simple, check_name=False)
 


### PR DESCRIPTION
## Summary
- prevent look-ahead bias when computing diff-sign features
- assert diff-sign columns exist for all median windows
- add EMA, normalized band and simple return features

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6869f22db4f0832ca1c4921dda8d4feb