### PR TITLE
Add training predictions commit step

### DIFF
--- a/.github/workflows/Monthly_taining_dayly_prediction.yml
+++ b/.github/workflows/Monthly_taining_dayly_prediction.yml
@@ -67,6 +67,21 @@ jobs:
             token=${PUSH_TOKEN:-$GITHUB_TOKEN}
             git push https://x-access-token:${token}@github.com/${{ github.repository }}.git HEAD:${{ github.ref }}
           fi
+      - name: Commit training predictions
+        env:
+          PUSH_TOKEN: ${{ secrets.GH_PAT }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git config user.name "github-actions"
+          git config user.email "github-actions@github.com"
+          git add results/trainingpreds/fullpredict.csv 2>/dev/null || true
+          if git diff --cached --quiet; then
+            echo "No training prediction changes to commit"
+          else
+            git commit -m "Update training predictions"
+            token=${PUSH_TOKEN:-$GITHUB_TOKEN}
+            git push https://x-access-token:${token}@github.com/${{ github.repository }}.git HEAD:${{ github.ref }}
+          fi
       - run: python -m src.predict
       - run: python -m src.portfolio.optimize
       - run: python -m src.notify.notifier --message "Proceso mensual completado"

--- a/README.md
+++ b/README.md
@@ -211,6 +211,7 @@ En `.github/workflows` encontraras los flujos que ejecutan el pipeline de forma 
 
 
 * `Monthly_taining_dayly_prediction.yml` ejecuta el entrenamiento completo cada tres meses y guarda los modelos resultantes en la carpeta `models/`. Tras entrenar se realiza un commit automatico con cualquier archivo `.joblib`, `.json` o `.keras` nuevo o actualizado para mantener la version mas reciente en el repositorio. Las métricas se escriben en `results/metrics` y las variables seleccionadas en `results/features`.
+  Adicionalmente, se genera `results/trainingpreds/fullpredict.csv` con las predicciones de entrenamiento para cada modelo.
 * `weekly.yml` genera la version agregada semanalmente del ABT. Se ejecuta cada lunes y sube los archivos como artefactos.
 * `monthly_abt.yml` genera la version agregada mensual del ABT. Se ejecuta cada mes y sube los archivos como artefactos.
 * `daily.yml` procesa los datos nuevos y aplica **unicamente** los modelos almacenados en `models/`; no ejecuta ninguna fase de entrenamiento. Las predicciones se escriben en `results/predicts/daily_predictions.csv` y se suben mediante un commit automatico cuando existen cambios.


### PR DESCRIPTION
## Summary
- add commit step for training predictions to monthly workflow
- document training predictions file in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686a116268d4832c9c951d272025015d