### PR TITLE
Adjust daily process schedule

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -3,7 +3,7 @@ permissions:
   contents: write
 on:
   schedule:
-    - cron: '0 2 * * *'
+    - cron: '0 3 * * *'
   workflow_dispatch: {}
 jobs:
   predict:


### PR DESCRIPTION
## Summary
- add an extra buffer before running the daily workflow by shifting the cron schedule to 03:00 UTC

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686ca12bc824832c80a1e74d607f36f4