### PR TITLE
Implement edge prediction daily process

### DIFF
--- a/tests/test_predictions.py
+++ b/tests/test_predictions.py
@@ -19,3 +19,21 @@ def test_predictions_file_and_order(tmp_path):
     pred_file = tmp_path / 'predicts' / '2025-07-07_daily_predictions.csv'
     assert pred_file.exists()
     assert result.columns[-1] == 'parameters'
+
+
+def test_edge_prediction_and_metrics(tmp_path):
+    df = pd.DataFrame(
+        {'Close': [1, 2, 3, 4, 5, 6]},
+        index=pd.date_range('2020-01-01', periods=6)
+    )
+    models = {'TEST_dummy': predict._NaiveModel()}
+    predict.RESULTS_DIR = tmp_path
+    predict.RUN_TIMESTAMP = '2025-07-08T00:00:00+00:00'
+
+    result = predict.run_predictions(models, {'TEST': df[:-1]}, frequency='daily')
+    edge_file = predict.save_edge_predictions(result)
+    assert edge_file.exists()
+
+    predict.evaluate_edge_predictions({'TEST': df}, edge_file)
+    metrics_file = tmp_path / 'metrics' / 'edge_daily_2020-01-06.csv'
+    assert metrics_file.exists()


### PR DESCRIPTION
## Summary
- extend `run_predictions` to record predicted date
- add helpers to aggregate edge predictions and evaluate them once actual data is available
- update CLI workflow to save edge predictions and compute edge metrics
- test edge prediction path

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686ca0ed15a0832ca8816788e9c46bc3