### PR TITLE
Add election and month-end features

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ Ademas existen scripts de seleccion y prediccion en la raiz del paquete para eje
   Puedes pasar `--frequency weekly` o `--frequency monthly` para obtener la ABT agregada en esas periodicidades.
   Esto baja datos historicos y agrega indicadores tecnicos. Antes de ejecutarlo puedes editar `config.yaml` para cambiar los tickers o el rango de fechas. Durante la ejecucion se imprimen las primeras filas de cada DataFrame y sus dimensiones para que puedas seguir el avance.
    La ABT final incluye ademas las nuevas variables de rezago (1, 7 y 14 dias) y las medias moviles de 13 y 26 dias del cierre.
+   Tambien se agregan columnas booleanas que marcan feriados (`is_holiday`, `next_is_holiday`, `prev_is_holiday`), el dia de elecciones en EE.UU. (`is_election_day`, `next_is_election_day`) y el cierre de mes (`is_month_end`).
 
 3. **Entrenamiento**
 


### PR DESCRIPTION
## Summary
- add helper to compute US election days
- mark election days and month end in seasonal features
- test new indicators
- document the columns in README
- mark when the previous calendar day is a holiday

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686cabdb4fc4832cb96dc3d05ff83d04