### PR TITLE
Improve dataset logging

### DIFF
--- a/src/evaluation.py
+++ b/src/evaluation.py
@@ -31,6 +31,7 @@ def evaluate_predictions(y_true: Sequence[float], y_pred: Sequence[float]) -> di
         "R2": r2,
         "EVS": evs,
     }
+    logger.info("Evaluation metrics: %s", metrics)
     return {k: round(v, 4) for k, v in metrics.items()}
 
 

--- a/src/features.py
+++ b/src/features.py
@@ -5,6 +5,10 @@ import numpy as np
 import pandas as pd
 import ta
 from pandas.tseries.holiday import USFederalHolidayCalendar
+import logging
+from .utils import log_df_details
+
+logger = logging.getLogger(__name__)
 
 
 def _us_election_days(start: pd.Timestamp, end: pd.Timestamp) -> pd.DatetimeIndex:
@@ -246,5 +250,8 @@ def add_technical_indicators(df: pd.DataFrame) -> pd.DataFrame:
         return group
 
     if "Ticker" in df.columns:
-        return df.groupby("Ticker", group_keys=False).apply(enrich)
-    return enrich(df)
+        result = df.groupby("Ticker", group_keys=False).apply(enrich)
+    else:
+        result = enrich(df)
+    log_df_details("technical indicators", result)
+    return result

--- a/src/utils/__init__.py
+++ b/src/utils/__init__.py
@@ -78,7 +78,7 @@ def timed_stage(name: str):
         logger.info("-" * 40)
 
 
-def log_df_details(name: str, df: Optional[pd.DataFrame], head: int = 5) -> None:
+def log_df_details(name: str, df: Optional[pd.DataFrame], head: int = 3) -> None:
     """Log basic DataFrame information."""
     logger = logging.getLogger(__name__)
     if df is None:

--- a/src/variable_selection.py
+++ b/src/variable_selection.py
@@ -3,6 +3,10 @@ from __future__ import annotations
 
 import numpy as np
 import pandas as pd
+import logging
+from .utils import log_df_details
+
+logger = logging.getLogger(__name__)
 
 
 def remove_multicollinearity(df: pd.DataFrame, threshold: float = 0.9) -> pd.DataFrame:
@@ -77,6 +81,7 @@ def select_features_rf_cv(
     from sklearn.model_selection import TimeSeriesSplit
 
     df = df.dropna(subset=[target_col])
+    log_df_details("feature selection input", df)
     features = df.drop(columns=[target_col])
     y = df[target_col]
 
@@ -99,4 +104,6 @@ def select_features_rf_cv(
     order = np.argsort(importances)[::-1]
     top_cols = features.columns[order[:max_features]]
     filtered = remove_multicollinearity(features[top_cols], threshold=corr_threshold)
+    logger.info("Selected features: %s", list(filtered.columns))
+    log_df_details("selected features df", filtered)
     return list(filtered.columns)


### PR DESCRIPTION
## Summary
- show more concise dataframe logs by default
- record metrics in `evaluate_predictions`
- add dataset snapshots in feature engineering and feature selection

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686e01985e54832cb53219578957f815