### PR TITLE
Simplify keras path creation

### DIFF
--- a/src/training.py
+++ b/src/training.py
@@ -445,8 +445,7 @@ def train_models(
                     n_iter=1,
                     cv_splits=cv_splitter.n_splits,
                 )
-                lstm_path = MODEL_DIR / f"{ticker}_{frequency}_lstm.pkl"
-                keras_path = lstm_path.with_suffix('.keras')
+                keras_path = MODEL_DIR / f"{ticker}_{frequency}_lstm.keras"
                 lstm.save(keras_path)
                 features_path = keras_path.with_name(keras_path.stem + '_features.json')
                 with open(features_path, 'w') as fh:


### PR DESCRIPTION
## Summary
- remove `lstm_path` variable when saving LSTM model
- create `keras_path` directly with `.keras` extension

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6870a663b458832c85e18a42abbe4893