### PR TITLE
Fix workflow naming

### DIFF
--- a/.github/workflows/Monthly_training_daily_prediction.yml
+++ b/.github/workflows/Monthly_training_daily_prediction.yml
@@ -1,4 +1,4 @@
-name: Monthly_taining_dayly_prediction
+name: Monthly_training_daily_prediction
 permissions:
   contents: write
 on:

--- a/README.md
+++ b/README.md
@@ -211,7 +211,7 @@ sequenceDiagram
 En `.github/workflows` encontraras los flujos que ejecutan el pipeline de forma programada:
 
 
-* `Monthly_taining_dayly_prediction.yml` ejecuta el entrenamiento completo cada tres meses y guarda los modelos resultantes en la carpeta `models/`. Tras entrenar se realiza un commit automatico con cualquier archivo `.joblib`, `.json` o `.keras` nuevo o actualizado para mantener la version mas reciente en el repositorio. Las métricas se escriben en `results/metrics` y las variables seleccionadas en `results/features`.
+* `Monthly_training_daily_prediction.yml` ejecuta el entrenamiento completo cada tres meses y guarda los modelos resultantes en la carpeta `models/`. Tras entrenar se realiza un commit automatico con cualquier archivo `.joblib`, `.json` o `.keras` nuevo o actualizado para mantener la version mas reciente en el repositorio. Las métricas se escriben en `results/metrics` y las variables seleccionadas en `results/features`.
   Adicionalmente, se genera `results/trainingpreds/fullpredict.csv` con las predicciones de entrenamiento para cada modelo.
 * `weekly.yml` genera la version agregada semanalmente del ABT. Se ejecuta cada lunes y sube los archivos como artefactos.
 * `monthly_abt.yml` genera la version agregada mensual del ABT. Se ejecuta cada mes y sube los archivos como artefactos.


### PR DESCRIPTION
## Summary
- rename workflow file `Monthly_taining_dayly_prediction.yml`
- update references in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6870a66916e4832c90e1c5921865bedb