### PR TITLE
Add cleanup step and new model path

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,2 @@
-models/*.pkl filter=lfs diff=lfs merge=lfs -text
-models/*.keras filter=lfs diff=lfs merge=lfs -text
+models/daily/*.pkl filter=lfs diff=lfs merge=lfs -text
+models/daily/*.keras filter=lfs diff=lfs merge=lfs -text

--- a/.github/workflows/Monthly_training_daily_prediction.yml
+++ b/.github/workflows/Monthly_training_daily_prediction.yml
@@ -28,6 +28,8 @@ jobs:
           pip install --upgrade pip
           pip install yfinance==0.2.61 ta==0.11.0 requests-cache==1.2.0 pandas>=2.2
           pip install -r requirements.txt
+      - name: Cleanup models
+        run: python -m src.clean_models
       - run: python -m src.training
       - name: Upload ABT artifacts
         uses: actions/upload-artifact@v4
@@ -41,9 +43,9 @@ jobs:
         run: |
           git config user.name "github-actions"
           git config user.email "github-actions@github.com"
-          git add models/*.joblib 2>/dev/null || true
-          git add models/*.json 2>/dev/null || true
-          git add models/*.keras 2>/dev/null || true
+          git add models/daily/*.joblib 2>/dev/null || true
+          git add models/daily/*.json 2>/dev/null || true
+          git add models/daily/*.keras 2>/dev/null || true
           if git diff --cached --quiet; then
             echo "No model changes to commit"
           else

--- a/.github/workflows/Monthly_training_weekly_prediction.yml
+++ b/.github/workflows/Monthly_training_weekly_prediction.yml
@@ -41,9 +41,9 @@ jobs:
         run: |
           git config user.name "github-actions"
           git config user.email "github-actions@github.com"
-          git add models/*.joblib 2>/dev/null || true
-          git add models/*.json 2>/dev/null || true
-          git add models/*.keras 2>/dev/null || true
+          git add models/daily/*.joblib 2>/dev/null || true
+          git add models/daily/*.json 2>/dev/null || true
+          git add models/daily/*.keras 2>/dev/null || true
           if git diff --cached --quiet; then
             echo "No model changes to commit"
           else

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ flowchart TB
 La carpeta `src` contiene las utilidades principales. Algunos scripts son plantillas listas para que agregues tu logica.
 
 * `abt/` crea la "Analytic Base Table" con datos diarios descargados y enriquecidos.
-* `models/` almacena ejemplos de modelos de machine learning y los modelos entrenados mensualmente.
+* `models/daily/` almacena ejemplos de modelos de machine learning y los modelos entrenados mensualmente.
   Estos archivos `.joblib`, `.json` y `.keras` se rastrean mediante **Git LFS**, por lo que conviene ejecutar `git lfs install` y `git lfs pull` tras clonar el proyecto.
 * `portfolio/` ofrece herramientas para optimizacion de cartera.
 * `notify/` muestra como enviar un mensaje con los resultados.
@@ -127,7 +127,7 @@ Ademas existen scripts de seleccion y prediccion en la raiz del paquete para eje
    python -m src.training
    ```
 
-   Se generan varios modelos de ejemplo y se guardan en `models/`. Actualmente
+   Se generan varios modelos de ejemplo y se guardan en `models/daily/`. Actualmente
    se entrenan regresión lineal, Random Forest, XGBoost, LightGBM, LSTM y ARIMA.
   Cada entrenamiento utiliza por defecto los últimos **12 meses** de datos
    (más unos 50 días extra para calcular las medias móviles) y reserva la
@@ -211,13 +211,13 @@ sequenceDiagram
 En `.github/workflows` encontraras los flujos que ejecutan el pipeline de forma programada:
 
 
-* `Monthly_training_daily_prediction.yml` ejecuta el entrenamiento completo cada tres meses y guarda los modelos resultantes en la carpeta `models/`. Tras entrenar se realiza un commit automatico con cualquier archivo `.joblib`, `.json` o `.keras` nuevo o actualizado para mantener la version mas reciente en el repositorio. Las métricas se escriben en `results/metrics` y las variables seleccionadas en `results/features`.
+* `Monthly_training_daily_prediction.yml` ejecuta el entrenamiento completo cada tres meses y guarda los modelos resultantes en la carpeta `models/daily/`. Tras entrenar se realiza un commit automatico con cualquier archivo `.joblib`, `.json` o `.keras` nuevo o actualizado para mantener la version mas reciente en el repositorio. Las métricas se escriben en `results/metrics` y las variables seleccionadas en `results/features`.
   Adicionalmente, se genera `results/trainingpreds/fullpredict.csv` con las predicciones de entrenamiento para cada modelo.
 * `weekly.yml` genera la version agregada semanalmente del ABT. Se ejecuta cada lunes y sube los archivos como artefactos.
 * `monthly_abt.yml` genera la version agregada mensual del ABT. Se ejecuta cada mes y sube los archivos como artefactos.
 * `Monthly_training_weekly_prediction.yml` reentrena los modelos cada mes usando datos semanales y realiza un pronóstico del promedio de la siguiente semana.
 * `weekly_process.yml` utiliza los modelos almacenados para predecir la próxima semana. Guarda `results/predicts/<fecha>_weekly_predictions.csv` y realiza un commit automático si hay cambios.
-* `daily.yml` procesa los datos nuevos y aplica **unicamente** los modelos almacenados en `models/`; no ejecuta ninguna fase de entrenamiento. Las predicciones se escriben en `results/predicts/<fecha>_daily_predictions.csv` y se suben mediante un commit automatico cuando existen cambios.
+* `daily.yml` procesa los datos nuevos y aplica **unicamente** los modelos almacenados en `models/daily/`; no ejecuta ninguna fase de entrenamiento. Las predicciones se escriben en `results/predicts/<fecha>_daily_predictions.csv` y se suben mediante un commit automatico cuando existen cambios.
 
 
 Para que estos flujos suban cambios por ti, revisa que `GITHUB_TOKEN` tenga permisos de escritura. Si trabajas en un fork, crea un *Personal Access Token* y guárdalo como `GH_PAT`. ¡Listo!

--- a/config.yaml
+++ b/config.yaml
@@ -14,7 +14,7 @@ start_date: "2015-01-01"
 prediction_horizon: 5
 risk_free_rate: 0.015
 data_dir: "data"
-model_dir: "models"
+model_dir: "models/daily"
 evaluation_dir: "results/metrics"
 target_cols:
   SPY: Close


### PR DESCRIPTION
## Summary
- move saved models to `models/daily`
- clean out models before monthly training
- track new directory with Git LFS
- update docs for new path

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6871b218f030832cb9ad84dcc8ec488d