### PR TITLE
Add weekly models directory support

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,4 @@
-models/*.pkl filter=lfs diff=lfs merge=lfs -text
-models/*.keras filter=lfs diff=lfs merge=lfs -text
+models/daily/*.pkl filter=lfs diff=lfs merge=lfs -text
+models/daily/*.keras filter=lfs diff=lfs merge=lfs -text
+models/weekly/*.pkl filter=lfs diff=lfs merge=lfs -text
+models/weekly/*.keras filter=lfs diff=lfs merge=lfs -text

--- a/.github/workflows/Monthly_training_daily_prediction.yml
+++ b/.github/workflows/Monthly_training_daily_prediction.yml
@@ -28,6 +28,8 @@ jobs:
           pip install --upgrade pip
           pip install yfinance==0.2.61 ta==0.11.0 requests-cache==1.2.0 pandas>=2.2
           pip install -r requirements.txt
+      - name: Cleanup models
+        run: python -m src.clean_models
       - run: python -m src.training
       - name: Upload ABT artifacts
         uses: actions/upload-artifact@v4
@@ -41,9 +43,9 @@ jobs:
         run: |
           git config user.name "github-actions"
           git config user.email "github-actions@github.com"
-          git add models/*.joblib 2>/dev/null || true
-          git add models/*.json 2>/dev/null || true
-          git add models/*.keras 2>/dev/null || true
+          git add models/daily/*.joblib 2>/dev/null || true
+          git add models/daily/*.json 2>/dev/null || true
+          git add models/daily/*.keras 2>/dev/null || true
           if git diff --cached --quiet; then
             echo "No model changes to commit"
           else

--- a/.github/workflows/Monthly_training_weekly_prediction.yml
+++ b/.github/workflows/Monthly_training_weekly_prediction.yml
@@ -41,9 +41,9 @@ jobs:
         run: |
           git config user.name "github-actions"
           git config user.email "github-actions@github.com"
-          git add models/*.joblib 2>/dev/null || true
-          git add models/*.json 2>/dev/null || true
-          git add models/*.keras 2>/dev/null || true
+          git add models/weekly/*.joblib 2>/dev/null || true
+          git add models/weekly/*.json 2>/dev/null || true
+          git add models/weekly/*.keras 2>/dev/null || true
           if git diff --cached --quiet; then
             echo "No model changes to commit"
           else

--- a/README.md
+++ b/README.md
@@ -92,7 +92,8 @@ flowchart TB
 La carpeta `src` contiene las utilidades principales. Algunos scripts son plantillas listas para que agregues tu logica.
 
 * `abt/` crea la "Analytic Base Table" con datos diarios descargados y enriquecidos.
-* `models/` almacena ejemplos de modelos de machine learning y los modelos entrenados mensualmente.
+* `models/daily/` almacena ejemplos de modelos de machine learning y los modelos entrenados mensualmente.
+* `models/weekly/` almacena los modelos entrenados con datos semanales.
   Estos archivos `.joblib`, `.json` y `.keras` se rastrean mediante **Git LFS**, por lo que conviene ejecutar `git lfs install` y `git lfs pull` tras clonar el proyecto.
 * `portfolio/` ofrece herramientas para optimizacion de cartera.
 * `notify/` muestra como enviar un mensaje con los resultados.
@@ -127,8 +128,9 @@ Ademas existen scripts de seleccion y prediccion en la raiz del paquete para eje
    python -m src.training
    ```
 
-   Se generan varios modelos de ejemplo y se guardan en `models/`. Actualmente
-   se entrenan regresión lineal, Random Forest, XGBoost, LightGBM, LSTM y ARIMA.
+   Se generan varios modelos de ejemplo y se guardan en `models/daily/`.
+   Con `--frequency weekly` los modelos se guardan en `models/weekly/`.
+   Actualmente se entrenan regresión lineal, Random Forest, XGBoost, LightGBM, LSTM y ARIMA.
   Cada entrenamiento utiliza por defecto los últimos **12 meses** de datos
    (más unos 50 días extra para calcular las medias móviles) y reserva la
    última semana como conjunto de validación. Se aplica validación
@@ -211,13 +213,13 @@ sequenceDiagram
 En `.github/workflows` encontraras los flujos que ejecutan el pipeline de forma programada:
 
 
-* `Monthly_training_daily_prediction.yml` ejecuta el entrenamiento completo cada tres meses y guarda los modelos resultantes en la carpeta `models/`. Tras entrenar se realiza un commit automatico con cualquier archivo `.joblib`, `.json` o `.keras` nuevo o actualizado para mantener la version mas reciente en el repositorio. Las métricas se escriben en `results/metrics` y las variables seleccionadas en `results/features`.
+* `Monthly_training_daily_prediction.yml` ejecuta el entrenamiento completo cada tres meses y guarda los modelos resultantes en la carpeta `models/daily/`. Tras entrenar se realiza un commit automatico con cualquier archivo `.joblib`, `.json` o `.keras` nuevo o actualizado para mantener la version mas reciente en el repositorio. Las métricas se escriben en `results/metrics` y las variables seleccionadas en `results/features`.
   Adicionalmente, se genera `results/trainingpreds/fullpredict.csv` con las predicciones de entrenamiento para cada modelo.
 * `weekly.yml` genera la version agregada semanalmente del ABT. Se ejecuta cada lunes y sube los archivos como artefactos.
 * `monthly_abt.yml` genera la version agregada mensual del ABT. Se ejecuta cada mes y sube los archivos como artefactos.
-* `Monthly_training_weekly_prediction.yml` reentrena los modelos cada mes usando datos semanales y realiza un pronóstico del promedio de la siguiente semana.
+* `Monthly_training_weekly_prediction.yml` reentrena los modelos cada mes usando datos semanales, guarda los modelos en `models/weekly/` y realiza un pronóstico del promedio de la siguiente semana.
 * `weekly_process.yml` utiliza los modelos almacenados para predecir la próxima semana. Guarda `results/predicts/<fecha>_weekly_predictions.csv` y realiza un commit automático si hay cambios.
-* `daily.yml` procesa los datos nuevos y aplica **unicamente** los modelos almacenados en `models/`; no ejecuta ninguna fase de entrenamiento. Las predicciones se escriben en `results/predicts/<fecha>_daily_predictions.csv` y se suben mediante un commit automatico cuando existen cambios.
+* `daily.yml` procesa los datos nuevos y aplica **unicamente** los modelos almacenados en `models/daily/`; no ejecuta ninguna fase de entrenamiento. Las predicciones se escriben en `results/predicts/<fecha>_daily_predictions.csv` y se suben mediante un commit automatico cuando existen cambios.
 
 
 Para que estos flujos suban cambios por ti, revisa que `GITHUB_TOKEN` tenga permisos de escritura. Si trabajas en un fork, crea un *Personal Access Token* y guárdalo como `GH_PAT`. ¡Listo!

--- a/config.yaml
+++ b/config.yaml
@@ -14,7 +14,8 @@ start_date: "2015-01-01"
 prediction_horizon: 5
 risk_free_rate: 0.015
 data_dir: "data"
-model_dir: "models"
+model_dir: "models/daily"
+model_dir_weekly: "models/weekly"
 evaluation_dir: "results/metrics"
 target_cols:
   SPY: Close

--- a/src/predict.py
+++ b/src/predict.py
@@ -29,7 +29,15 @@ TARGET_COLS = CONFIG.get("target_cols", {})
 
 RESULTS_DIR = Path(__file__).resolve().parents[1] / "results"
 RESULTS_DIR.mkdir(exist_ok=True, parents=True)
-MODEL_DIR = Path(__file__).resolve().parents[1] / CONFIG.get("model_dir", "models")
+MODEL_DIR = Path(__file__).resolve().parents[1] / CONFIG.get("model_dir", "models/daily")
+
+
+def set_model_dir(frequency: str = "daily") -> None:
+    """Set the global MODEL_DIR based on frequency."""
+    global MODEL_DIR
+    key = "model_dir" if frequency == "daily" else f"model_dir_{frequency}"
+    dir_value = CONFIG.get(key, f"models/{frequency}")
+    MODEL_DIR = Path(__file__).resolve().parents[1] / dir_value
 
 
 def _is_lfs_pointer(path: Path) -> bool:
@@ -332,6 +340,7 @@ if __name__ == "__main__":
     )
     args = parser.parse_args()
 
+    set_model_dir(args.frequency)
     data_paths = build_abt(args.frequency)
     data = {t: pd.read_csv(p, index_col=0, parse_dates=True) for t, p in data_paths.items()}
     models = load_models(MODEL_DIR)

--- a/src/training.py
+++ b/src/training.py
@@ -40,8 +40,16 @@ logger = logging.getLogger(__name__)
 TARGET_COLS = CONFIG.get("target_cols", {})
 
 
-MODEL_DIR = Path(__file__).resolve().parents[1] / CONFIG.get("model_dir", "models")
-MODEL_DIR.mkdir(exist_ok=True, parents=True)
+MODEL_DIR = Path(__file__).resolve().parents[1] / CONFIG.get("model_dir", "models/daily")
+
+
+def set_model_dir(frequency: str = "daily") -> None:
+    """Set the global MODEL_DIR based on frequency."""
+    global MODEL_DIR
+    key = "model_dir" if frequency == "daily" else f"model_dir_{frequency}"
+    dir_value = CONFIG.get(key, f"models/{frequency}")
+    MODEL_DIR = Path(__file__).resolve().parents[1] / dir_value
+    MODEL_DIR.mkdir(exist_ok=True, parents=True)
 EVAL_DIR = Path(__file__).resolve().parents[1] / CONFIG.get(
     "evaluation_dir", "results/metrics"
 )
@@ -860,6 +868,7 @@ if __name__ == "__main__":
     )
     args = parser.parse_args()
 
+    set_model_dir(args.frequency)
     data_paths = build_abt(args.frequency)
     combined_path = data_paths.get("combined")
     if combined_path:


### PR DESCRIPTION
## Summary
- track new `models/weekly` directory under Git LFS
- allow training and prediction scripts to select model directory per frequency
- store weekly models in `models/weekly`
- document the new directory and workflow behaviour

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6871b218f030832cb9ad84dcc8ec488d