### PR TITLE
Fix pip cache error with stable setup-python

### DIFF
--- a/.github/workflows/Monthly_training_daily_prediction.yml
+++ b/.github/workflows/Monthly_training_daily_prediction.yml
@@ -16,13 +16,11 @@ jobs:
           lfs: true
       - name: Setup Git LFS
         run: git lfs install
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v5.1.1
         with:
+          # v5.2.0 falla cuando el cache de pip no existe
           python-version: 3.11
-      - uses: actions/cache@v4
-        with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements*.txt') }}
+          cache: "pip"
       - name: Instalar dependencias
         run: |
           pip install --upgrade pip


### PR DESCRIPTION
## Summary
- pin `actions/setup-python` to v5.1.1 and enable its builtin pip cache in `Monthly_training_daily_prediction.yml`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6871c1da1c0c832c8acef7183529ec5a