### PR TITLE
Enhance edge predictions and evaluation

### DIFF
--- a/tests/test_predictions.py
+++ b/tests/test_predictions.py
@@ -35,7 +35,7 @@ def test_edge_prediction_and_metrics(tmp_path):
     assert edge_file.exists()
 
     predict.evaluate_edge_predictions({'TEST': df}, edge_file)
-    metrics_file = tmp_path / 'metrics' / 'edge_daily_2020-01-06.csv'
+    metrics_file = tmp_path / 'edge_metrics' / 'edge_metrics_2020-01-06.csv'
     assert metrics_file.exists()
 
 
@@ -46,5 +46,5 @@ def test_edge_evaluation_no_file(tmp_path):
 
     result = predict.evaluate_edge_predictions({'TEST': df}, tmp_path / 'missing.csv')
     assert result is None
-    metrics_files = list((tmp_path / 'metrics').glob('edge_daily_*'))
+    metrics_files = list((tmp_path / 'edge_metrics').glob('edge_metrics_*'))
     assert not metrics_files


### PR DESCRIPTION
## Summary
- ensemble prediction uses float outputs
- pick algorithm names for predictions
- save edge predictions from top 3 models and add ensemble
- evaluate predictions per model and save under `edge_metrics`
- update tests for new metrics path

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6871f109867c832c904ecb274a5a7fc1