### PR TITLE
Save edge metrics in metrics folder

### DIFF
--- a/src/predict.py
+++ b/src/predict.py
@@ -356,11 +356,20 @@ def evaluate_edge_predictions(data: Dict[str, pd.DataFrame], prev_file: Path) ->
         return None
 
     metrics_df = pd.DataFrame(rows)
+
+    # Save metrics inside results/edge_metrics for backwards compatibility
     metrics_dir = RESULTS_DIR / "edge_metrics"
     metrics_dir.mkdir(exist_ok=True, parents=True)
     metrics_file = metrics_dir / f"edge_metrics_{predicted_date}.csv"
     metrics_df.to_csv(metrics_file, index=False)
     logger.info("Saved edge metrics to %s", metrics_file)
+
+    # Also store metrics in the main metrics folder
+    metrics_main_dir = RESULTS_DIR / "metrics"
+    metrics_main_dir.mkdir(exist_ok=True, parents=True)
+    metrics_main_file = metrics_main_dir / f"edge_metrics_{predicted_date}.csv"
+    metrics_df.to_csv(metrics_main_file, index=False)
+    logger.info("Saved edge metrics to %s", metrics_main_file)
     return metrics_df
 
 

--- a/tests/test_predictions.py
+++ b/tests/test_predictions.py
@@ -35,8 +35,10 @@ def test_edge_prediction_and_metrics(tmp_path):
     assert edge_file.exists()
 
     predict.evaluate_edge_predictions({'TEST': df}, edge_file)
-    metrics_file = tmp_path / 'edge_metrics' / 'edge_metrics_2020-01-06.csv'
-    assert metrics_file.exists()
+    metrics_file_edge = tmp_path / 'edge_metrics' / 'edge_metrics_2020-01-06.csv'
+    assert metrics_file_edge.exists()
+    metrics_file_main = tmp_path / 'metrics' / 'edge_metrics_2020-01-06.csv'
+    assert metrics_file_main.exists()
 
 
 def test_edge_evaluation_no_file(tmp_path):
@@ -48,3 +50,5 @@ def test_edge_evaluation_no_file(tmp_path):
     assert result is None
     metrics_files = list((tmp_path / 'edge_metrics').glob('edge_metrics_*'))
     assert not metrics_files
+    metrics_main_files = list((tmp_path / 'metrics').glob('edge_metrics_*'))
+    assert not metrics_main_files


### PR DESCRIPTION
## Summary
- store edge metrics in results/metrics in addition to the old edge_metrics folder
- adjust tests to validate new metrics location

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6875c6fb9b64832c8a5d9003ef25fa68