### PR TITLE
Fix edge metrics tracking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,8 @@ results/*
 !results/predicts/*.csv
 !results/metrics/
 !results/metrics/**
+!results/edge_metrics/
+!results/edge_metrics/**
 !results/features/
 !results/features/**
 !results/viz/


### PR DESCRIPTION
## Summary
- track `results/edge_metrics` output in gitignore so metrics are saved in repo

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6875e99e4ff0832c98b6dd9610269e61