### PR TITLE
Add real values to edge metrics

### DIFF
--- a/src/predict.py
+++ b/src/predict.py
@@ -357,7 +357,14 @@ def evaluate_edge_predictions(data: Dict[str, pd.DataFrame], prev_file: Path) ->
         target_col = TARGET_COLS.get(ticker, "Close")
         actual_val = df.loc[df.index[idx.get_loc(predicted_ts)], target_col]
         metrics = evaluate_predictions([actual_val], [pred_val])
-        rows.append({"ticker": ticker, "model": model_name, "pred": pred_val, "Predicted": str(predicted_date), **metrics})
+        rows.append({
+            "ticker": ticker,
+            "model": model_name,
+            "pred": pred_val,
+            "real": actual_val,
+            "Predicted": str(predicted_date),
+            **metrics,
+        })
 
     if not rows:
         return None

--- a/tests/test_predictions.py
+++ b/tests/test_predictions.py
@@ -39,6 +39,9 @@ def test_edge_prediction_and_metrics(tmp_path):
     assert metrics_file_edge.exists()
     metrics_file_main = tmp_path / 'metrics' / 'edge_metrics_2020-01-06.csv'
     assert metrics_file_main.exists()
+    mdf = pd.read_csv(metrics_file_edge)
+    assert 'pred' in mdf.columns
+    assert 'real' in mdf.columns
 
 
 def test_edge_evaluation_no_file(tmp_path):


### PR DESCRIPTION
## Summary
- include actual prices when evaluating edge predictions
- test that edge metrics CSV contains predicted and real columns

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6879457bf3fc832c82b05c8b9660df89