### PR TITLE
Update edge metrics with increment ratios

### DIFF
--- a/src/predict.py
+++ b/src/predict.py
@@ -372,13 +372,15 @@ def evaluate_edge_predictions(data: Dict[str, pd.DataFrame], prev_file: Path) ->
             prev_close = df.loc[df.index[loc - 1], target_col]
         pred_delta = None if prev_close is None else pred_val - prev_close
         real_delta = None if prev_close is None else actual_val - prev_close
-        pred_delta_pct = None
-        real_delta_pct = None
+        pred_inc = None
+        real_inc = None
         direction = None
         if prev_close not in (None, 0):
-            pred_delta_pct = (pred_delta / prev_close) * 100
-            real_delta_pct = (real_delta / prev_close) * 100
-            direction = real_delta > 0
+            pred_inc = (pred_val - prev_close) / prev_close
+            real_inc = (actual_val - prev_close) / prev_close
+            direction = (pred_inc > 0 and real_inc > 0) or (
+                pred_inc < 0 and real_inc < 0
+            )
         metrics = evaluate_predictions([actual_val], [pred_val])
         rows.append({
             "ticker": ticker,
@@ -387,8 +389,8 @@ def evaluate_edge_predictions(data: Dict[str, pd.DataFrame], prev_file: Path) ->
             "real": actual_val,
             "pred_delta": pred_delta,
             "real_delta": real_delta,
-            "pred_delta_pct": pred_delta_pct,
-            "real_delta_pct": real_delta_pct,
+            "pred_inc": pred_inc,
+            "real_inc": real_inc,
             "direction": direction,
             "Predicted": str(predicted_date),
             **metrics,

--- a/tests/test_predictions.py
+++ b/tests/test_predictions.py
@@ -44,8 +44,8 @@ def test_edge_prediction_and_metrics(tmp_path):
     assert 'real' in mdf.columns
     assert 'pred_delta' in mdf.columns
     assert 'real_delta' in mdf.columns
-    assert 'pred_delta_pct' in mdf.columns
-    assert 'real_delta_pct' in mdf.columns
+    assert 'pred_inc' in mdf.columns
+    assert 'real_inc' in mdf.columns
     assert 'direction' in mdf.columns
     # verify actual value corresponds to prediction date
     assert (mdf['Predicted'] == '2020-01-06').all()


### PR DESCRIPTION
## Summary
- change `evaluate_edge_predictions` to compute increment ratios instead of delta percentages
- update tests for new metric columns

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6879520789dc832c980d4fb15c328142