### PR TITLE
Add workflow to purge old results

### DIFF
--- a/.github/workflows/results_cleanup.yml
+++ b/.github/workflows/results_cleanup.yml
@@ -1,0 +1,39 @@
+name: Results Cleanup
+permissions:
+  contents: write
+on:
+  schedule:
+    - cron: '0 2 */30 * *'
+  workflow_dispatch: {}
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          persist-credentials: true
+      - uses: actions/setup-python@v5
+        with:
+          python-version: 3.11
+      - name: Install dependencies
+        run: |
+          pip install --upgrade pip
+          pip install -r requirements.txt
+      - name: Delete old result files
+        run: python -m src.clean_results
+      - name: Commit cleaned results
+        env:
+          PUSH_TOKEN: ${{ secrets.GH_PAT }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git config user.name "github-actions"
+          git config user.email "github-actions@github.com"
+          git add results
+          if git diff --cached --quiet; then
+            echo "No result files removed"
+          else
+            git commit -m "Remove old results"
+            token=${PUSH_TOKEN:-$GITHUB_TOKEN}
+            git push https://x-access-token:${token}@github.com/${{ github.repository }}.git HEAD:${{ github.ref }}
+          fi

--- a/src/clean_results.py
+++ b/src/clean_results.py
@@ -1,0 +1,38 @@
+"""Delete result files older than a certain age."""
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from datetime import datetime, timedelta
+
+logger = logging.getLogger(__name__)
+
+RESULTS_DIR = Path(__file__).resolve().parents[1] / "results"
+
+
+def delete_old_results(directory: Path = RESULTS_DIR, older_than: int = 90) -> None:
+    """Delete all files older than ``older_than`` days inside ``directory``."""
+    if not directory.exists():
+        logger.warning("Results directory %s does not exist", directory)
+        return
+
+    cutoff = datetime.now() - timedelta(days=older_than)
+    deleted = False
+    for path in directory.rglob("*"):
+        if not path.is_file():
+            continue
+        try:
+            if datetime.fromtimestamp(path.stat().st_mtime) < cutoff:
+                path.unlink()
+                logger.info("Deleted %s", path)
+                deleted = True
+        except Exception:  # pragma: no cover - log but continue
+            logger.exception("Failed to delete %s", path)
+
+    if not deleted:
+        logger.info("No result files older than %d days in %s", older_than, directory)
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    delete_old_results()


### PR DESCRIPTION
## Summary
- add a simple Python utility `clean_results.py` that removes result files older than 90 days
- create a `Results Cleanup` GitHub Actions workflow running every 30 days

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6879533b5340832c8090206a348da48f