### PR TITLE
Implement daily drift evaluation

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -47,6 +47,9 @@ jobs:
         run: |
           set -e
           python -m src.predict 2>&1 | tee predict.log || { echo "::error::Prediction failed"; exit 1; }
+      - name: Evaluate drift
+        run: |
+          python -m src.edge_drift
       - name: Commit results
         env:
           PUSH_TOKEN: ${{ secrets.GH_PAT }}
@@ -58,6 +61,7 @@ jobs:
           git add results/predicts/*_edge_prediction.csv 2>/dev/null || true
           git add results/metrics/edge_metrics_*.csv 2>/dev/null || true
           git add results/edge_metrics/*.csv 2>/dev/null || true
+          git add results/drift/*/drift_metrics.csv 2>/dev/null || true
           if git diff --cached --quiet; then
             echo "No changes to commit"
           else

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,8 @@ results/*
 !results/features/**
 !results/viz/
 !results/viz/**
+!results/drift/
+!results/drift/**
 
 # Byte-compiled / cache files
 __pycache__/

--- a/README.md
+++ b/README.md
@@ -170,21 +170,28 @@ La funcion de evaluacion calcula los siguientes indicadores:
 - **EVS**: varianza explicada por el modelo.
 
 
-6. **Optimizacion de portafolio**
+6. **Monitoreo de deriva**
+
+   ```bash
+   python -m src.edge_drift
+   ```
+   Genera un reporte con las metricas de los ultimos 15 dias de `results/edge_metrics` y calcula un puntaje de deriva.
+
+7. **Optimizacion de portafolio**
 
    ```bash
    python -m src.portfolio.optimize
    ```
    Ajusta los pesos segun tus reglas para armar un portafolio equilibrado.
 
-7. **Notificacion**
+8. **Notificacion**
 
    ```bash
    python -m src.notify.notifier --message "Proceso completo"
    ```
    Envía un aviso por correo o chat con los resultados finales.
 
-8. **Limpieza opcional**
+9. **Limpieza opcional**
 
    ```bash
    python -m src.clean_models_daily
@@ -219,7 +226,7 @@ En `.github/workflows` encontraras los flujos que ejecutan el pipeline de forma 
 * `monthly_abt.yml` genera la version agregada mensual del ABT. Se ejecuta cada mes y sube los archivos como artefactos.
 * `Monthly_training_weekly_prediction.yml` reentrena los modelos cada mes usando datos semanales y realiza un pronóstico del promedio de la siguiente semana.
 * `weekly_process.yml` utiliza los modelos almacenados para predecir la próxima semana. Guarda `results/predicts/<fecha>_weekly_predictions.csv` y realiza un commit automático si hay cambios.
-* `daily.yml` procesa los datos nuevos y aplica **unicamente** los modelos almacenados en `models/daily/`; no ejecuta ninguna fase de entrenamiento. Las predicciones se escriben en `results/predicts/<fecha>_daily_predictions.csv` y se suben mediante un commit automatico cuando existen cambios.
+* `daily.yml` procesa los datos nuevos y aplica **unicamente** los modelos almacenados en `models/daily/`; no ejecuta ninguna fase de entrenamiento. Las predicciones se escriben en `results/predicts/<fecha>_daily_predictions.csv`. Luego ejecuta `src.edge_drift` para evaluar la deriva y guarda un CSV en `results/drift/<fecha>` que también se sube mediante un commit automático cuando existen cambios.
 
 
 Para que estos flujos suban cambios por ti, revisa que `GITHUB_TOKEN` tenga permisos de escritura. Si trabajas en un fork, crea un *Personal Access Token* y guárdalo como `GH_PAT`. ¡Listo!
@@ -233,7 +240,8 @@ flowchart TD
     ABT --> TR[python -m src.training]
     TR --> PR[python -m src.predict]
     PR --> EV[python -m src.evaluation]
-    EV --> OP[python -m src.portfolio.optimize]
+    EV --> DR[python -m src.edge_drift]
+    DR --> OP[python -m src.portfolio.optimize]
     OP --> NT[python -m src.notify.notifier]
 ```
 

--- a/src/edge_drift.py
+++ b/src/edge_drift.py
@@ -1,0 +1,86 @@
+"""Evaluate drift based on recent edge metrics."""
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from datetime import date
+from typing import Dict
+
+import pandas as pd
+
+from .evaluation import evaluate_predictions
+
+logger = logging.getLogger(__name__)
+
+# Tolerance thresholds for each metric
+TOLERANCE: Dict[str, float] = {
+    "MAE": 1.0,
+    "MSE": 1.0,
+    "RMSE": 1.0,
+    "MAPE": 0.05,
+    "R2": 0.7,
+    "EVS": 0.7,
+}
+
+
+def _load_recent_metrics(directory: Path, days: int = 15) -> pd.DataFrame:
+    """Return concatenated edge metrics for the most recent ``days`` files."""
+    files = sorted(directory.glob("edge_metrics_*.csv"))
+    if not files:
+        return pd.DataFrame()
+    recent = files[-days:]
+    dfs = []
+    for file in recent:
+        try:
+            df = pd.read_csv(file, usecols=["ticker", "model", "pred", "real"])
+            dfs.append(df)
+        except Exception:
+            logger.exception("Failed to load %s", file)
+    return pd.concat(dfs, ignore_index=True) if dfs else pd.DataFrame()
+
+
+def evaluate_drift(data: pd.DataFrame) -> pd.DataFrame:
+    """Compute metrics and drift score for each ticker and model."""
+    if data.empty:
+        return pd.DataFrame()
+
+    records = []
+    for (ticker, model), grp in data.groupby(["ticker", "model"]):
+        y_true = grp["real"].tolist()
+        y_pred = grp["pred"].tolist()
+        metrics = evaluate_predictions(y_true, y_pred)
+        drift_hits = 0
+        for k, v in metrics.items():
+            thr = TOLERANCE.get(k)
+            if thr is None:
+                continue
+            if k in {"R2", "EVS"}:
+                if v < thr:
+                    drift_hits += 1
+            else:
+                if v > thr:
+                    drift_hits += 1
+        drift_score = drift_hits / len(TOLERANCE)
+        records.append({"ticker": ticker, "model": model, **metrics, "drift_score": round(drift_score, 4)})
+
+    return pd.DataFrame(records)
+
+
+def main(days: int = 15) -> Path:
+    """Load recent edge metrics and write drift evaluation."""
+    base_dir = Path(__file__).resolve().parents[1]
+    metrics_dir = base_dir / "results" / "edge_metrics"
+    df = _load_recent_metrics(metrics_dir, days)
+    result = evaluate_drift(df)
+    today = date.today().isoformat()
+    out_dir = base_dir / "results" / "drift" / f"edge_drift_evaluation_{today}"
+    out_dir.mkdir(parents=True, exist_ok=True)
+    out_file = out_dir / "drift_metrics.csv"
+    result.to_csv(out_file, index=False)
+    logger.info("Saved drift evaluation to %s", out_file)
+    return out_file
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    main()


### PR DESCRIPTION
## Summary
- track daily drift outputs
- implement `edge_drift` module
- document drift monitoring steps and workflow updates
- run daily workflow step for drift evaluation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687955adebc0832ca0dad58562d16767