### PR TITLE
Add daily graphs

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -76,3 +76,18 @@ jobs:
       - run: python -m src.notify.notifier --message "Proceso diario completado"
       - name: Generate viz tables
         run: python -m src.visualization
+      - name: Commit visualizations
+        env:
+          PUSH_TOKEN: ${{ secrets.GH_PAT }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git config user.name "github-actions"
+          git config user.email "github-actions@github.com"
+          git add results/viz/*.png results/viz/*.csv 2>/dev/null || true
+          if git diff --cached --quiet; then
+            echo "No visualization changes to commit"
+          else
+            git commit -m "Update daily visualizations"
+            token=${PUSH_TOKEN:-$GITHUB_TOKEN}
+            git push https://x-access-token:${token}@github.com/${{ github.repository }}.git HEAD:${{ github.ref }}
+          fi

--- a/README.md
+++ b/README.md
@@ -257,3 +257,13 @@ for fold, (train_idx, test_idx) in enumerate(hybrid_cv_split(X)):
 ```
 
 Esto produciría como máximo diez particiones desplazando la ventana a lo largo del tiempo.
+
+## Visualizaciones diarias
+
+Estas imágenes se generan a partir de los datos más recientes y se actualizan todos los días.
+
+![Gráfica de precios](results/viz/candlestick.png)
+
+![Predicción vs Real](results/viz/pred_vs_real.png)
+
+![Variables destacadas](results/viz/best_variables.png)

--- a/src/visualization.py
+++ b/src/visualization.py
@@ -99,11 +99,66 @@ def prepare_best_variables(top_n: int = 5) -> pd.DataFrame:
     return top_df
 
 
+def _plot_candlestick(df: pd.DataFrame, out_file: Path) -> None:
+    """Create line plot of closing prices."""
+    if df.empty:
+        return
+    import matplotlib.pyplot as plt
+
+    pivot = df.pivot(index="Date", columns="ticker", values="Close")
+    pivot.plot(figsize=(10, 4))
+    plt.title("Precio de cierre - últimos 60 días")
+    plt.xlabel("Fecha")
+    plt.ylabel("Cierre")
+    plt.tight_layout()
+    plt.savefig(out_file)
+    plt.close()
+
+
+def _plot_pred_vs_real(df: pd.DataFrame, out_file: Path) -> None:
+    """Scatter plot of predicted vs real prices."""
+    if df.empty:
+        return
+    import matplotlib.pyplot as plt
+
+    fig, ax = plt.subplots(figsize=(5, 5))
+    ax.scatter(df["real"], df["pred"], alpha=0.7)
+    min_val = min(df["real"].min(), df["pred"].min())
+    max_val = max(df["real"].max(), df["pred"].max())
+    ax.plot([min_val, max_val], [min_val, max_val], "r--", linewidth=1)
+    ax.set_xlabel("Real")
+    ax.set_ylabel("Predicción")
+    ax.set_title("Predicción vs Real")
+    plt.tight_layout()
+    plt.savefig(out_file)
+    plt.close()
+
+
+def _plot_best_variables(df: pd.DataFrame, out_file: Path) -> None:
+    """Bar plot of feature importance."""
+    if df.empty:
+        return
+    import matplotlib.pyplot as plt
+
+    fig, ax = plt.subplots(figsize=(8, 4))
+    df.plot(kind="barh", x="feature", y="importance_mean", ax=ax)
+    ax.set_xlabel("Importancia")
+    ax.set_ylabel("Variable")
+    ax.set_title("Variables más importantes")
+    plt.tight_layout()
+    plt.savefig(out_file)
+    plt.close()
+
+
 def create_viz_tables() -> None:
     """Generate all visualization tables."""
-    prepare_candlestick_data()
-    prepare_pred_vs_real()
-    prepare_best_variables()
+    candle_df = prepare_candlestick_data()
+    pred_df = prepare_pred_vs_real()
+    best_df = prepare_best_variables()
+
+    _plot_candlestick(candle_df, VIZ_DIR / "candlestick.png")
+    _plot_pred_vs_real(pred_df, VIZ_DIR / "pred_vs_real.png")
+    _plot_best_variables(best_df, VIZ_DIR / "best_variables.png")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- generate PNG visualizations using matplotlib
- commit visualizations in the daily workflow
- display daily graphs in the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687956bc93a0832c8504fc6197ec80db