### PR TITLE
Update drift metrics output path

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -61,7 +61,7 @@ jobs:
           git add results/predicts/*_edge_prediction.csv 2>/dev/null || true
           git add results/metrics/edge_metrics_*.csv 2>/dev/null || true
           git add results/edge_metrics/*.csv 2>/dev/null || true
-          git add results/drift/*/drift_metrics.csv 2>/dev/null || true
+          git add results/drift/*.csv 2>/dev/null || true
           if git diff --cached --quiet; then
             echo "No changes to commit"
           else

--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ En `.github/workflows` encontraras los flujos que ejecutan el pipeline de forma 
 * `monthly_abt.yml` genera la version agregada mensual del ABT. Se ejecuta cada mes y sube los archivos como artefactos.
 * `Monthly_training_weekly_prediction.yml` reentrena los modelos cada mes usando datos semanales y realiza un pronóstico del promedio de la siguiente semana.
 * `weekly_process.yml` utiliza los modelos almacenados para predecir la próxima semana. Guarda `results/predicts/<fecha>_weekly_predictions.csv` y realiza un commit automático si hay cambios.
-* `daily.yml` procesa los datos nuevos y aplica **unicamente** los modelos almacenados en `models/daily/`; no ejecuta ninguna fase de entrenamiento. Las predicciones se escriben en `results/predicts/<fecha>_daily_predictions.csv`. Luego ejecuta `src.edge_drift` para evaluar la deriva y guarda un CSV en `results/drift/<fecha>` que también se sube mediante un commit automático cuando existen cambios.
+* `daily.yml` procesa los datos nuevos y aplica **unicamente** los modelos almacenados en `models/daily/`; no ejecuta ninguna fase de entrenamiento. Las predicciones se escriben en `results/predicts/<fecha>_daily_predictions.csv`. Luego ejecuta `src.edge_drift` para evaluar la deriva y guarda un CSV en `results/drift/edge_drift_evaluation_<fecha>.csv` que también se sube mediante un commit automático cuando existen cambios.
 
 
 Para que estos flujos suban cambios por ti, revisa que `GITHUB_TOKEN` tenga permisos de escritura. Si trabajas en un fork, crea un *Personal Access Token* y guárdalo como `GH_PAT`. ¡Listo!

--- a/src/edge_drift.py
+++ b/src/edge_drift.py
@@ -73,9 +73,13 @@ def main(days: int = 15) -> Path:
     df = _load_recent_metrics(metrics_dir, days)
     result = evaluate_drift(df)
     today = date.today().isoformat()
-    out_dir = base_dir / "results" / "drift" / f"edge_drift_evaluation_{today}"
-    out_dir.mkdir(parents=True, exist_ok=True)
-    out_file = out_dir / "drift_metrics.csv"
+    out_file = (
+        base_dir
+        / "results"
+        / "drift"
+        / f"edge_drift_evaluation_{today}.csv"
+    )
+    out_file.parent.mkdir(parents=True, exist_ok=True)
     result.to_csv(out_file, index=False)
     logger.info("Saved drift evaluation to %s", out_file)
     return out_file


### PR DESCRIPTION
## Summary
- save drift metrics as a single CSV file instead of folder
- adjust workflow commit step to include new file
- document new drift metrics location

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6879cc818d68832c9abe3f90279f9537