### PR TITLE
Save daily visualizations as SVG

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -87,7 +87,7 @@ jobs:
         run: |
           git config user.name "github-actions"
           git config user.email "github-actions@github.com"
-          git add results/viz/*.png results/viz/*.csv 2>/dev/null || true
+          git add results/viz/*.png results/viz/*.svg results/viz/*.csv 2>/dev/null || true
           if git diff --cached --quiet; then
             echo "No visualization changes to commit"
           else

--- a/README.md
+++ b/README.md
@@ -269,6 +269,7 @@ Esto produciría como máximo diez particiones desplazando la ventana a lo largo
 ## Visualizaciones diarias
 
 Estas imágenes se generan a partir de los datos más recientes y se actualizan todos los días.
+Además de las versiones PNG, el flujo guarda copias en formato SVG dentro de la misma carpeta.
 
 ![Gráfica de precios](results/viz/candlestick.png)
 

--- a/src/visualization.py
+++ b/src/visualization.py
@@ -112,6 +112,7 @@ def _plot_candlestick(df: pd.DataFrame, out_file: Path) -> None:
     plt.ylabel("Cierre")
     plt.tight_layout()
     plt.savefig(out_file)
+    plt.savefig(out_file.with_suffix(".svg"))
     plt.close()
 
 
@@ -131,6 +132,7 @@ def _plot_pred_vs_real(df: pd.DataFrame, out_file: Path) -> None:
     ax.set_title("Predicción vs Real")
     plt.tight_layout()
     plt.savefig(out_file)
+    plt.savefig(out_file.with_suffix(".svg"))
     plt.close()
 
 
@@ -147,6 +149,7 @@ def _plot_best_variables(df: pd.DataFrame, out_file: Path) -> None:
     ax.set_title("Variables más importantes")
     plt.tight_layout()
     plt.savefig(out_file)
+    plt.savefig(out_file.with_suffix(".svg"))
     plt.close()
 
 


### PR DESCRIPTION
## Summary
- save PNG plots as SVG too in `src.visualization`
- include SVG files when committing visualizations
- document new SVG files in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6879cb5e7690832c9e8a277c35928ddc