### PR TITLE
Add prediction artifact validation, intraday period/fallback fixes, improved feature imputation, and dashboard quality flags

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -53,34 +53,51 @@ jobs:
       - name: Validate prediction artifacts non-empty
         run: |
           python - <<'PY'
+          from datetime import datetime, timezone
           from pathlib import Path
           import pandas as pd
 
-          root = Path('results/predicts')
-          daily_files = sorted(root.glob('*_daily_predictions.csv'))
-          edge_files = sorted(root.glob('*_edge_prediction.csv'))
-          if not daily_files:
-              raise SystemExit('No daily prediction file was generated')
-          if not edge_files:
-              raise SystemExit('No edge prediction file was generated')
+          run_date = datetime.now(timezone.utc).date().isoformat()
+          pred_root = Path("results/predicts")
+          metrics_root = Path("results/metrics")
 
-          def latest_valid(files: list[Path], required: set[str], kind: str) -> Path:
-              for path in sorted(files, reverse=True):
-                  try:
-                      df = pd.read_csv(path)
-                  except pd.errors.EmptyDataError:
-                      continue
-                  if df.empty:
-                      continue
-                  missing = required - set(df.columns)
-                  if missing:
-                      continue
-                  return path
-              raise SystemExit(f'No valid {kind} file found with required columns: {sorted(required)}')
+          daily_file = pred_root / f"{run_date}_daily_predictions.csv"
+          edge_file = pred_root / f"{run_date}_edge_prediction.csv"
 
-          daily_file = latest_valid(daily_files, {'ticker', 'model', 'actual', 'pred'}, 'daily prediction')
-          edge_file = latest_valid(edge_files, {'ticker', 'model', 'pred'}, 'edge prediction')
-          print(f'Validated prediction outputs: {daily_file.name}, {edge_file.name}')
+          def fail(path: Path, reason: str) -> None:
+              raise SystemExit(f"[prediction-artifact-error] {path.as_posix()}: {reason}")
+
+          def validate_csv(path: Path, required: set[str]) -> None:
+              if not path.exists():
+                  fail(path, "file_not_found")
+              if not path.is_file():
+                  fail(path, "not_a_file")
+              if path.stat().st_size == 0:
+                  fail(path, "empty_file")
+              try:
+                  df = pd.read_csv(path)
+              except pd.errors.EmptyDataError:
+                  fail(path, "csv_parse_error_empty_data")
+              except Exception as exc:
+                  fail(path, f"csv_parse_error:{type(exc).__name__}")
+              if df.empty and len(df.columns) == 0:
+                  fail(path, "csv_parse_error_no_columns")
+              missing = sorted(required - set(df.columns))
+              if missing:
+                  fail(path, f"missing_columns:{missing}")
+              if len(df) == 0:
+                  fail(path, "zero_rows")
+
+          validate_csv(daily_file, {"ticker", "model", "actual", "pred"})
+          validate_csv(edge_file, {"ticker", "model", "pred", "Predicted"})
+          print(f"[prediction-artifact-ok] validated run_date={run_date} files: {daily_file.name}, {edge_file.name}")
+
+          # Optional historical check: diagnostics only; never used for pass/fail of today's prediction.
+          historical_metrics = sorted(metrics_root.glob("edge_metrics_*.csv"))
+          if not historical_metrics:
+              print("::warning::No historical edge_metrics_*.csv files found (optional check).")
+          else:
+              print(f"[optional-metrics-check] latest historical metric file: {historical_metrics[-1].name}")
           PY
       - name: Evaluate drift
         run: |

--- a/docs/js/scripts.js
+++ b/docs/js/scripts.js
@@ -619,14 +619,24 @@ document.addEventListener('DOMContentLoaded', () => {
     renderActionableCenter(report);
 
     const health = report.pipeline_health || {};
+    const dataQuality = report.data_quality || {};
+    const predictionsValid = dataQuality.predictions_valid !== false;
+    const qualityCause = dataQuality.cause || 'ok';
     runDate.textContent = report.run_date || health.run_date || 'N/D';
-    status.textContent = health.status || 'N/D';
+    status.textContent = predictionsValid
+      ? (health.status || 'N/D')
+      : `${health.status || 'DEGRADADO'} · ⚠ Predicciones inválidas`;
     success.textContent = `${Number(health.success_pct || 0).toFixed(2)}% (${health.successful_steps || 0}/${health.total_steps || 0})`;
     fallback.textContent = health.fallback_offline || 'No detectado';
 
     const edgeCoverage = report.summary?.edge_coverage || {};
+    const qualityWarning = predictionsValid
+      ? ''
+      : `<li style="color:#ffb020;font-weight:700;"><strong>⚠ Calidad de predicciones:</strong> inválida (${qualityCause}). Revisar artefacto del último run.</li>`;
     artifactsList.innerHTML = `
+      ${qualityWarning}
       <li><strong>Predicciones:</strong> ${report.artifacts?.predictions_file || 'n/a'}</li>
+      <li><strong>Predicciones válidas:</strong> ${predictionsValid ? 'Sí' : 'No'}</li>
       <li><strong>Métricas:</strong> ${report.artifacts?.metrics_file || 'n/a'}</li>
       <li><strong>Edge metrics:</strong> ${report.artifacts?.edge_metrics_file || 'n/a'}</li>
       <li><strong>Cobertura edge:</strong> ${edgeCoverage.rows || 0} filas, ${edgeCoverage.tickers || 0} tickers, ${edgeCoverage.models || 0} modelos.</li>

--- a/src/abt/build_abt.py
+++ b/src/abt/build_abt.py
@@ -119,6 +119,15 @@ def _is_intraday_interval(interval: str) -> bool:
     return interval in {"1m", "2m", "5m", "15m", "30m", "60m", "90m", "1h"}
 
 
+def _intraday_period_for_interval(interval: str) -> str:
+    """Return a Yahoo-compatible period for each intraday interval."""
+    if interval == "1m":
+        return "8d"
+    if interval in {"2m", "5m"}:
+        return "60d"
+    return "730d"
+
+
 def _normalize_ts(ts: pd.Timestamp) -> pd.Timestamp:
     ts = pd.Timestamp(ts)
     if ts.tzinfo is not None:
@@ -184,7 +193,7 @@ def download_ticker(
         for attempt in range(1, retries + 1):
             try:
                 if _is_intraday_interval(interval):
-                    period = "60d" if interval in {"1m", "2m", "5m"} else "730d"
+                    period = _intraday_period_for_interval(interval)
                     df = yf.download(
                         ticker,
                         period=period,
@@ -208,7 +217,7 @@ def download_ticker(
                 df = pd.DataFrame()
             time.sleep(1)
 
-        if df.empty:
+        if df.empty and not _is_intraday_interval(interval):
             try:
                 df = _download_stooq(ticker, start_dt, today)
                 logger.info("Stooq suministró %d filas para %s", len(df), ticker)

--- a/src/monitoring/data_latency.py
+++ b/src/monitoring/data_latency.py
@@ -19,6 +19,39 @@ ROOT_DIR = Path(__file__).resolve().parents[2]
 LATENCY_DIR = ROOT_DIR / "results" / "latency"
 
 
+def _interval_to_minutes(interval: str) -> int | None:
+    if interval.endswith("m"):
+        return int(interval[:-1])
+    if interval.endswith("h"):
+        return int(interval[:-1]) * 60
+    return None
+
+
+def _is_intraday_granularity(index: pd.Index) -> bool:
+    if len(index) < 1:
+        return False
+    parsed = pd.to_datetime(index, errors="coerce")
+    parsed = parsed.dropna()
+    if len(parsed) < 1:
+        return False
+    if len(parsed) == 1:
+        ts = parsed[0]
+        return bool(ts.hour or ts.minute or ts.second)
+
+    series = pd.Series(parsed).sort_values()
+    diffs = series.diff().dropna()
+    if diffs.empty:
+        return False
+    min_step = diffs.min()
+    return pd.Timedelta(0) < min_step <= pd.Timedelta(hours=12)
+
+
+def _is_recent_intraday_bar(latency_minutes: float, interval: str) -> bool:
+    interval_minutes = _interval_to_minutes(interval) or 60
+    freshness_limit = max(interval_minutes * 3, 180)
+    return latency_minutes <= freshness_limit
+
+
 def _to_utc_timestamp(ts: pd.Timestamp) -> pd.Timestamp:
     parsed = pd.Timestamp(ts)
     if parsed.tzinfo is None:
@@ -42,14 +75,24 @@ def measure_ticker_latency(ticker: str, intervals: list[str]) -> dict[str, objec
 
         last_bar_ts = _to_utc_timestamp(frame.index.max())
         latency_minutes = round((download_time_utc - last_bar_ts.to_pydatetime()).total_seconds() / 60.0, 2)
+        granularity_ok = _is_intraday_granularity(frame.index)
+        recent_ok = _is_recent_intraday_bar(latency_minutes, interval)
+        if not granularity_ok:
+            status = "invalid_granularity"
+        elif not recent_ok:
+            status = "stale_intraday"
+        else:
+            status = "ok"
         return {
             "ticker": ticker,
             "download_time_utc": download_time_utc.isoformat(),
             "last_bar_timestamp": last_bar_ts.isoformat(),
             "latency_minutes": latency_minutes,
+            "interval_requested": interval,
             "interval_used": interval,
             "source": "yfinance",
-            "status": "ok",
+            "granularity_ok": bool(granularity_ok),
+            "status": status,
         }
 
     return {
@@ -57,8 +100,10 @@ def measure_ticker_latency(ticker: str, intervals: list[str]) -> dict[str, objec
         "download_time_utc": download_time_utc.isoformat(),
         "last_bar_timestamp": "",
         "latency_minutes": "",
+        "interval_requested": ",".join(intervals),
         "interval_used": "",
         "source": "yfinance",
+        "granularity_ok": False,
         "status": "no_data",
     }
 

--- a/src/predict.py
+++ b/src/predict.py
@@ -244,7 +244,41 @@ def _next_prediction_timestamp(index: pd.Index, frequency: str):
     return last_ts + pd.offsets.BDay()
 
 
-def _prepare_prediction_inputs(df: pd.DataFrame, target_col: str) -> tuple[pd.DataFrame, pd.DataFrame]:
+def _feature_fill_values_for_model(model: Any, feature_list: list[str]) -> dict[str, float]:
+    """Return per-feature fill values, preferring trained medians when available."""
+    fill_values: dict[str, float] = {col: 0.0 for col in feature_list}
+    if not feature_list:
+        return fill_values
+
+    if hasattr(model, "feature_medians_"):
+        raw = getattr(model, "feature_medians_")
+        if isinstance(raw, dict):
+            for col in feature_list:
+                if col in raw and pd.notna(raw[col]):
+                    fill_values[col] = float(raw[col])
+    elif hasattr(model, "medians_"):
+        raw = getattr(model, "medians_")
+        if isinstance(raw, dict):
+            for col in feature_list:
+                if col in raw and pd.notna(raw[col]):
+                    fill_values[col] = float(raw[col])
+    elif hasattr(model, "imputer_statistics_") and hasattr(model, "feature_names_in_"):
+        stats = np.asarray(getattr(model, "imputer_statistics_", []))
+        names = list(getattr(model, "feature_names_in_", []))
+        if len(stats) == len(names):
+            stats_by_col = {name: float(val) for name, val in zip(names, stats) if pd.notna(val)}
+            for col in feature_list:
+                if col in stats_by_col:
+                    fill_values[col] = stats_by_col[col]
+    return fill_values
+
+
+def _prepare_prediction_inputs(
+    df: pd.DataFrame,
+    target_col: str,
+    feature_list: list[str] | None = None,
+    feature_fill_values: dict[str, float] | None = None,
+) -> tuple[pd.DataFrame, pd.DataFrame, dict[str, int]]:
     """Return a cleaned ABT copy and numeric feature matrix ready for prediction."""
     prepared = df.copy()
     if "delta" not in prepared.columns:
@@ -254,8 +288,31 @@ def _prepare_prediction_inputs(df: pd.DataFrame, target_col: str) -> tuple[pd.Da
     if "Ticker" in X:
         X = X.drop(columns=["Ticker"])
     X = X.select_dtypes(exclude="object")
-    X = X.replace([np.inf, -np.inf], np.nan).dropna()
-    return prepared, X
+    X = X.replace([np.inf, -np.inf], np.nan)
+
+    diagnostics = {"columns_all_nan": 0, "rows_discarded": 0, "columns_imputed": 0}
+    diagnostics["columns_all_nan"] = int(X.isna().all(axis=0).sum())
+    X = X.dropna(axis=1, how="all")
+
+    expected_features = list(feature_list or [])
+    if expected_features:
+        missing_expected = [c for c in expected_features if c not in X.columns]
+        for col in missing_expected:
+            X[col] = 0.0
+        X = X.reindex(columns=expected_features)
+        fill_values = {
+            col: float((feature_fill_values or {}).get(col, 0.0))
+            for col in expected_features
+        }
+        has_missing = X[expected_features].isna().any(axis=0)
+        diagnostics["columns_imputed"] = int(has_missing.sum())
+        if diagnostics["columns_imputed"]:
+            X.loc[:, expected_features] = X[expected_features].fillna(fill_values)
+
+    rows_before = len(X)
+    X = X.dropna(axis=0, how="any")
+    diagnostics["rows_discarded"] = rows_before - len(X)
+    return prepared, X, diagnostics
 
 
 def run_predictions(
@@ -267,7 +324,7 @@ def run_predictions(
     rows = []
     diagnostics = Counter()
     diagnostics["models_received"] = len(models)
-    prepared_by_ticker: Dict[str, tuple[pd.DataFrame, pd.DataFrame, str]] = {}
+    prepared_by_ticker: Dict[tuple[str, tuple[str, ...]], tuple[pd.DataFrame, pd.DataFrame, str]] = {}
     for name, model_info in models.items():
         if isinstance(model_info, tuple):
             model, feature_list, schema_hash = model_info
@@ -286,7 +343,21 @@ def run_predictions(
         ticker = _model_ticker(name)
         algo = parts[2] if len(parts) > 2 else getattr(model, "__class__", type(model)).__name__
         target_col = TARGET_COLS.get(ticker, "Close")
-        prepared_pack = prepared_by_ticker.get(ticker)
+        selected_features: list[str] | None = None
+        if feature_list is not None:
+            selected_features = list(feature_list)
+        else:
+            feature_file = MODEL_DIR / f"{name}_features.json"
+            if feature_file.exists():
+                try:
+                    with feature_file.open() as fh:
+                        selected_features = list(json.load(fh))
+                except Exception:
+                    diagnostics["feature_alignment_errors"] += 1
+                    logger.exception("Failed to load feature list for %s", name)
+
+        cache_key = (ticker, tuple(selected_features or []))
+        prepared_pack = prepared_by_ticker.get(cache_key)
 
         if prepared_pack is None:
             df = data.get(ticker)
@@ -306,13 +377,26 @@ def run_predictions(
                 )
                 target_col = "Close"
 
-            prepared_df, prepared_X = _prepare_prediction_inputs(df, target_col)
+            fill_values = _feature_fill_values_for_model(model, selected_features or [])
+            prepared_df, prepared_X, prep_diag = _prepare_prediction_inputs(
+                df,
+                target_col,
+                feature_list=selected_features,
+                feature_fill_values=fill_values,
+            )
+            logger.info(
+                "Ticker %s diagnostics: columnas_all_nan=%s filas_descartadas=%s columnas_imputadas=%s",
+                ticker,
+                prep_diag["columns_all_nan"],
+                prep_diag["rows_discarded"],
+                prep_diag["columns_imputed"],
+            )
             if prepared_X.empty:
                 diagnostics["skipped_empty_features"] += 1
                 logger.warning("All rows have NaN/inf features for %s", ticker)
                 continue
-            prepared_by_ticker[ticker] = (prepared_df, prepared_X, target_col)
-            prepared_pack = prepared_by_ticker[ticker]
+            prepared_by_ticker[cache_key] = (prepared_df, prepared_X, target_col)
+            prepared_pack = prepared_by_ticker[cache_key]
 
         df, base_X, target_col = prepared_pack
         X = base_X
@@ -326,17 +410,6 @@ def run_predictions(
                 diagnostics["skipped_schema_mismatch"] += 1
                 logger.exception("Schema mismatch for %s", name)
                 continue
-            X = X.reindex(columns=feature_list, fill_value=0)
-        else:
-            feature_file = MODEL_DIR / f"{name}_features.json"
-            if feature_file.exists():
-                try:
-                    with feature_file.open() as fh:
-                        selected = json.load(fh)
-                    X = X.reindex(columns=selected, fill_value=0)
-                except Exception:
-                    diagnostics["feature_alignment_errors"] += 1
-                    logger.exception("Failed to align features for %s", name)
 
         train_start = df.index.min().date()
         train_end = df.index.max().date()

--- a/src/visualization.py
+++ b/src/visualization.py
@@ -97,17 +97,51 @@ def _latest_csv(directory: Path, pattern: str) -> Path | None:
     return files[-1] if files else None
 
 
-def _latest_valid_prediction_csv() -> Path | None:
-    """Return the most recent non-empty daily prediction CSV with required fields."""
+def _latest_prediction_run_csv() -> Path | None:
+    """Return prediction CSV for the most recent run date, without validating content."""
+    candidates: list[tuple[object, Path]] = []
+    for candidate in PRED_DIR.glob("*_daily_predictions.csv"):
+        run_date = candidate.stem.split("_")[0]
+        parsed = pd.to_datetime(run_date, errors="coerce") if pd is not None else run_date
+        if pd is not None and pd.isna(parsed):
+            continue
+        candidates.append((parsed, candidate))
+
+    if not candidates:
+        return None
+
+    candidates.sort(key=lambda row: row[0])
+    return candidates[-1][1]
+
+
+def _prediction_artifact_quality(pred_file: Path | None) -> dict:
+    """Validate prediction artifact quality for a specific run date file."""
     required = {"ticker", "actual", "pred"}
-    for candidate in sorted(PRED_DIR.glob("*_daily_predictions.csv"), reverse=True):
-        df = _safe_read_csv(candidate)
-        if df is None or df.empty:
-            continue
-        if not required.issubset(df.columns):
-            continue
-        return candidate
-    return None
+    out = {"predictions_valid": False, "cause": "missing_file"}
+    if pred_file is None or not pred_file.exists():
+        return out
+
+    if pred_file.stat().st_size == 0:
+        out["cause"] = "empty_file"
+        return out
+
+    pred_df = _safe_read_csv(pred_file)
+    if pred_df is None:
+        out["cause"] = "read_error"
+        return out
+    if pred_df.empty and len(pred_df.columns) == 0:
+        out["cause"] = "empty_file"
+        return out
+    if not required.issubset(pred_df.columns):
+        out["cause"] = "missing_columns"
+        return out
+    if len(pred_df) == 0:
+        out["cause"] = "zero_rows"
+        return out
+
+    out["predictions_valid"] = True
+    out["cause"] = "ok"
+    return out
 
 
 def _latest_csv_for_run_date(directory: Path, prefix: str, run_date: str) -> Path | None:
@@ -573,7 +607,7 @@ def prepare_pipeline_health() -> "pd.DataFrame | None":
 
     evaluation_dir = EDGE_METRICS_DIR
     required_steps = 5
-    latest_pred_file = _latest_valid_prediction_csv()
+    latest_pred_file = _latest_prediction_run_csv()
     out_file = VIZ_DIR / "pipeline_health.csv"
 
     if latest_pred_file is None:
@@ -594,6 +628,7 @@ def prepare_pipeline_health() -> "pd.DataFrame | None":
         return empty
 
     run_date = latest_pred_file.stem.split("_")[0]
+    prediction_quality = _prediction_artifact_quality(latest_pred_file)
     step_paths: dict[str, Path | None] = {
         "features": _latest_csv_for_run_date(FEATURE_DIR, "features_daily_", run_date),
         "training": _latest_csv_for_run_date(METRICS_DIR, "metrics_daily_", run_date),
@@ -613,7 +648,7 @@ def prepare_pipeline_health() -> "pd.DataFrame | None":
 
     pred_df = _safe_read_csv(latest_pred_file)
     fallback_offline = "No detectado"
-    if pred_df is None or pred_df.empty:
+    if not prediction_quality["predictions_valid"] or pred_df is None or pred_df.empty:
         fallback_offline = "Posible fallback (predicción vacía)"
     elif "actual" in pred_df.columns:
         actual = pd.to_numeric(pred_df["actual"], errors="coerce").dropna()
@@ -626,6 +661,8 @@ def prepare_pipeline_health() -> "pd.DataFrame | None":
         status = "DEGRADADO"
     else:
         status = "CRÍTICO"
+    if not prediction_quality["predictions_valid"]:
+        status = "DEGRADADO" if success_pct >= 60 else "CRÍTICO"
 
     out = pd.DataFrame(
         [
@@ -637,6 +674,8 @@ def prepare_pipeline_health() -> "pd.DataFrame | None":
                 "total_steps": required_steps,
                 "fallback_offline": fallback_offline,
                 "status": status,
+                "predictions_valid": bool(prediction_quality["predictions_valid"]),
+                "prediction_quality_cause": prediction_quality["cause"],
             }
         ]
     )
@@ -928,7 +967,8 @@ def prepare_last_run_report(
         return None
 
     report_file = VIZ_DIR / "last_run_report.json"
-    latest_pred_file = _latest_valid_prediction_csv()
+    latest_pred_file = _latest_prediction_run_csv()
+    prediction_quality = _prediction_artifact_quality(latest_pred_file)
     latest_metrics_file = _latest_csv(METRICS_DIR, "metrics_daily_*.csv")
     latest_edge_file = _latest_csv(EDGE_METRICS_DIR, "edge_metrics_*.csv")
 
@@ -1040,6 +1080,10 @@ def prepare_last_run_report(
     report = {
         "generated_at": datetime.now(timezone.utc).isoformat(),
         "run_date": run_date,
+        "data_quality": {
+            "predictions_valid": bool(prediction_quality["predictions_valid"]),
+            "cause": prediction_quality["cause"],
+        },
         "artifacts": {
             "predictions_file": latest_pred_file.name if latest_pred_file else "n/a",
             "metrics_file": latest_metrics_file.name if latest_metrics_file else "n/a",

--- a/tests/test_build_abt_incremental.py
+++ b/tests/test_build_abt_incremental.py
@@ -174,6 +174,75 @@ def test_download_ticker_offline_uses_long_history_sample(monkeypatch):
     assert captured["periods"] >= 260
 
 
+def test_download_ticker_intraday_uses_compatible_periods(monkeypatch):
+    module = __import__("src.abt.build_abt", fromlist=["dummy"])
+    monkeypatch.setattr(module, "_internet_ok", lambda: True)
+
+    calls = []
+
+    def fake_yf_download(*args, **kwargs):
+        calls.append(kwargs)
+        idx = pd.date_range("2026-01-01 09:30", periods=3, freq="1min")
+        return pd.DataFrame(
+            {
+                "Open": [1.0, 1.0, 1.0],
+                "High": [1.0, 1.0, 1.0],
+                "Low": [1.0, 1.0, 1.0],
+                "Close": [1.0, 1.0, 1.0],
+                "Adj Close": [1.0, 1.0, 1.0],
+                "Volume": [100, 100, 100],
+            },
+            index=idx,
+        )
+
+    monkeypatch.setattr(module.yf, "download", fake_yf_download)
+
+    module.download_ticker("AAA", "2024-01-01", interval="1m")
+    module.download_ticker("AAA", "2024-01-01", interval="5m")
+
+    assert calls[0]["interval"] == "1m"
+    assert calls[0]["period"] == "8d"
+    assert calls[1]["interval"] == "5m"
+    assert calls[1]["period"] == "60d"
+
+
+def test_download_ticker_intraday_does_not_use_stooq_fallback(monkeypatch):
+    module = __import__("src.abt.build_abt", fromlist=["dummy"])
+    monkeypatch.setattr(module, "_internet_ok", lambda: True)
+    monkeypatch.setattr(module.yf, "download", lambda *args, **kwargs: pd.DataFrame())
+
+    stooq_calls = {"count": 0}
+    sample_calls = {"count": 0}
+
+    def fake_stooq(*args, **kwargs):
+        stooq_calls["count"] += 1
+        return pd.DataFrame()
+
+    def fake_sample(start, periods=30):
+        sample_calls["count"] += 1
+        idx = pd.date_range("2024-01-01", periods=5, freq="D")
+        return pd.DataFrame(
+            {
+                "Open": [1.0] * 5,
+                "High": [1.0] * 5,
+                "Low": [1.0] * 5,
+                "Close": [1.0] * 5,
+                "Adj Close": [1.0] * 5,
+                "Volume": [100] * 5,
+            },
+            index=idx,
+        )
+
+    monkeypatch.setattr(module, "_download_stooq", fake_stooq)
+    monkeypatch.setattr(module, "generate_sample_data", fake_sample)
+
+    out = module.download_ticker("AAA", "2024-01-01", interval="1m", retries=1)
+
+    assert not out.empty
+    assert stooq_calls["count"] == 0
+    assert sample_calls["count"] == 1
+
+
 def test_build_abt_full_daily_uses_batch_download(monkeypatch, tmp_path):
     module = __import__("src.abt.build_abt", fromlist=["dummy"])
 

--- a/tests/test_data_latency.py
+++ b/tests/test_data_latency.py
@@ -1,0 +1,43 @@
+from datetime import datetime, timezone
+
+import pandas as pd
+
+import src.monitoring.data_latency as latency
+
+
+class _FrozenDateTime:
+    @classmethod
+    def now(cls, tz=None):
+        base = datetime(2026, 3, 21, 15, 0, tzinfo=timezone.utc)
+        if tz is None:
+            return base
+        return base.astimezone(tz)
+
+
+def test_measure_ticker_latency_marks_invalid_granularity(monkeypatch):
+    idx = pd.date_range("2026-03-18", periods=3, freq="D")
+    frame = pd.DataFrame({"Close": [1.0, 1.0, 1.0]}, index=idx)
+
+    monkeypatch.setattr(latency, "datetime", _FrozenDateTime)
+    monkeypatch.setattr(latency, "download_ticker", lambda **kwargs: frame)
+
+    out = latency.measure_ticker_latency("AAA", ["1m"])
+
+    assert out["interval_requested"] == "1m"
+    assert out["interval_used"] == "1m"
+    assert out["source"] == "yfinance"
+    assert out["granularity_ok"] is False
+    assert out["status"] == "invalid_granularity"
+
+
+def test_measure_ticker_latency_requires_recent_intraday_bar(monkeypatch):
+    idx = pd.date_range("2026-03-21 13:00", periods=3, freq="1h", tz="UTC")
+    frame = pd.DataFrame({"Close": [1.0, 1.0, 1.0]}, index=idx)
+
+    monkeypatch.setattr(latency, "datetime", _FrozenDateTime)
+    monkeypatch.setattr(latency, "download_ticker", lambda **kwargs: frame)
+
+    out = latency.measure_ticker_latency("AAA", ["1h"])
+
+    assert out["granularity_ok"] is True
+    assert out["status"] == "ok"

--- a/tests/test_predictions.py
+++ b/tests/test_predictions.py
@@ -1,4 +1,5 @@
 import pytest
+import json
 
 pd = pytest.importorskip("pandas")
 
@@ -189,3 +190,32 @@ def test_save_edge_predictions_empty_output_keeps_expected_columns(tmp_path):
 
     assert list(written.columns) == ["ticker", "model", "pred", "Predicted"]
     assert written.empty
+
+
+def test_run_predictions_daily_bucket_columns_all_nan_still_predicts(tmp_path):
+    class _DummyModel:
+        def predict(self, X):
+            return [float(X.sum(axis=1).iloc[0])]
+
+    predict.RESULTS_DIR = tmp_path
+    predict.MODEL_DIR = tmp_path
+    predict.RUN_TIMESTAMP = "2025-07-12T00:00:00+00:00"
+
+    model_name = "TEST_daily_dummy"
+    (tmp_path / f"{model_name}_features.json").write_text(
+        json.dumps(["delta", "bucket_return_mean_hist", "bucket_return_vol_hist"])
+    )
+
+    df = pd.DataFrame(
+        {
+            "Close": [10.0, 11.0, 12.0],
+            "bucket_return_mean_hist": [float("nan"), float("nan"), float("nan")],
+            "bucket_return_vol_hist": [float("nan"), float("nan"), float("nan")],
+        },
+        index=pd.date_range("2025-01-01", periods=3),
+    )
+
+    result = predict.run_predictions({model_name: _DummyModel()}, {"TEST": df}, frequency="daily")
+
+    assert not result.empty
+    assert result.loc[0, "ticker"] == "TEST"

--- a/tests/test_visualization_dashboard.py
+++ b/tests/test_visualization_dashboard.py
@@ -33,6 +33,8 @@ def test_prepare_pipeline_health_writes_summary(tmp_path, monkeypatch):
         "total_steps",
         "fallback_offline",
         "status",
+        "predictions_valid",
+        "prediction_quality_cause",
     ]
     assert out.loc[0, "run_date"] == run_date
     assert out.loc[0, "successful_steps"] >= 4
@@ -405,7 +407,10 @@ def test_prepare_pipeline_health_ignores_latest_empty_prediction_file(tmp_path, 
     monkeypatch.setattr(viz, "VIZ_DIR", viz_dir)
     out = viz.prepare_pipeline_health()
     assert out is not None
-    assert out.loc[0, "run_date"] == valid_run
+    assert out.loc[0, "run_date"] == empty_run
+    assert out.loc[0, "predictions_valid"] == False
+    assert out.loc[0, "prediction_quality_cause"] == "empty_file"
+    assert out.loc[0, "status"] in {"DEGRADADO", "CRÍTICO"}
 def test_prepare_last_run_report_ignores_latest_empty_prediction_file(tmp_path, monkeypatch):
     root = tmp_path
     pred_dir = root / "predicts"
@@ -432,8 +437,36 @@ def test_prepare_last_run_report_ignores_latest_empty_prediction_file(tmp_path, 
     monkeypatch.setattr(viz, "VIZ_DIR", viz_dir)
     report = viz.prepare_last_run_report(pd.DataFrame(), pd.DataFrame(), pd.DataFrame())
     assert report is not None
-    assert report["run_date"] == valid_run
-    assert report["artifacts"]["predictions_file"] == f"{valid_run}_daily_predictions.csv"
+    assert report["run_date"] == empty_run
+    assert report["artifacts"]["predictions_file"] == f"{empty_run}_daily_predictions.csv"
+    assert report["data_quality"]["predictions_valid"] is False
+    assert report["data_quality"]["cause"] == "empty_file"
+
+
+def test_prepare_last_run_report_marks_missing_columns_as_invalid(tmp_path, monkeypatch):
+    root = tmp_path
+    pred_dir = root / "predicts"
+    metrics_dir = root / "metrics"
+    edge_dir = root / "edge_metrics"
+    viz_dir = root / "viz"
+    for directory in [pred_dir, metrics_dir, edge_dir, viz_dir]:
+        directory.mkdir(parents=True, exist_ok=True)
+
+    run_date = "2026-03-12"
+    pd.DataFrame([{"ticker": "AAA", "pred": 101.0}]).to_csv(
+        pred_dir / f"{run_date}_daily_predictions.csv", index=False
+    )
+    monkeypatch.setattr(viz, "PRED_DIR", pred_dir)
+    monkeypatch.setattr(viz, "METRICS_DIR", metrics_dir)
+    monkeypatch.setattr(viz, "EDGE_METRICS_DIR", edge_dir)
+    monkeypatch.setattr(viz, "VIZ_DIR", viz_dir)
+
+    report = viz.prepare_last_run_report(pd.DataFrame(), pd.DataFrame(), pd.DataFrame())
+
+    assert report is not None
+    assert report["run_date"] == run_date
+    assert report["data_quality"]["predictions_valid"] is False
+    assert report["data_quality"]["cause"] == "missing_columns"
 def test_prepare_edge_metrics_reads_from_edge_metrics_dir(tmp_path, monkeypatch):
     root = tmp_path
     metrics_dir = root / "metrics"


### PR DESCRIPTION
### Motivation
- Make the pipeline more robust by validating prediction artifacts produced each run and surface quality issues to the dashboard. 
- Ensure intraday downloads use Yahoo-compatible `period` values and avoid inappropriate fallbacks for high-frequency data. 
- Improve prediction input handling so models can still predict when some feature columns are all-NaN by using trained medians/imputer statistics. 

### Description
- Add strict CSV validation for daily and edge prediction artifacts in the CI workflow (`.github/workflows/daily.yml`) including explicit failure reasons and optional historical metrics diagnostics. 
- Introduce `_intraday_period_for_interval` in `src/abt/build_abt.py` and use it when calling `yf.download`, and prevent the Stooq fallback for intraday intervals. 
- Implement intraday freshness and granularity checks in `src/monitoring/data_latency.py` with `_interval_to_minutes`, `_is_intraday_granularity`, and `_is_recent_intraday_bar`, and expose `granularity_ok` and `interval_requested` in the latency report. 
- Overhaul prediction input preparation in `src/predict.py` by adding `_feature_fill_values_for_model`, enhancing `_prepare_prediction_inputs` to reindex expected features, impute using model medians/statistics, return diagnostics, and cache prepared data per `(ticker, feature_list)`. 
- Update visualization code in `src/visualization.py` to select the latest run-date file, add `_prediction_artifact_quality` checks, annotate pipeline health and `last_run_report` payloads with `data_quality` and `prediction_quality_cause`, and adjust status logic accordingly. 
- Update dashboard JavaScript `docs/js/scripts.js` to surface prediction-quality warnings and show `predictions_valid` status and cause. 
- Add and update unit tests to cover intraday period selection, no-Stooq fallback for intraday, latency granularity/freshness, predictions handling when feature buckets are all-NaN, and visualization/reporting of invalid prediction artifacts. 

### Testing
- Ran unit tests under `tests/` including `test_build_abt_incremental.py`, `test_data_latency.py`, `test_predictions.py`, and `test_visualization_dashboard.py`, which exercise intraday period logic, stooq fallback behavior, latency checks, feature imputation, and pipeline health/report generation, and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bec1462cf4832c885aef3eaae05189)